### PR TITLE
Trial tables only use experiment_id as partition key

### DIFF
--- a/database_schemas/cassandra/benchflow.cql
+++ b/database_schemas/cassandra/benchflow.cql
@@ -310,7 +310,7 @@ CREATE TABLE trial_process_duration (
   process_duration_sd float,
   experiment_id text,
   trial_id text,
-  PRIMARY KEY ((trial_id,experiment_id))
+  PRIMARY KEY ((experiment_id))
 );
 
 CREATE TABLE trial_cpu (
@@ -332,7 +332,7 @@ CREATE TABLE trial_cpu (
   cpu_integral float,
   experiment_id text,
   trial_id text,
-  PRIMARY KEY ((trial_id,experiment_id))
+  PRIMARY KEY ((experiment_id))
 );
 
 CREATE TABLE trial_ram (
@@ -354,7 +354,7 @@ CREATE TABLE trial_ram (
   ram_integral float,
   experiment_id text,
   trial_id text,
-  PRIMARY KEY ((trial_id,experiment_id))
+  PRIMARY KEY ((experiment_id))
 );
 
 CREATE TABLE trial_throughput (
@@ -362,19 +362,19 @@ CREATE TABLE trial_throughput (
   execution_time bigint,
   experiment_id text,
   trial_id text,
-  PRIMARY KEY ((trial_id,experiment_id))
+  PRIMARY KEY ((experiment_id))
 );
 
 CREATE TABLE trial_number_of_process_instances (
   number_of_process_instances bigint,
   experiment_id text,
   trial_id text,
-  PRIMARY KEY ((trial_id,experiment_id))
+  PRIMARY KEY ((experiment_id))
 );
 
 CREATE TABLE trial_byte_size (
   size bigint,
   experiment_id text,
   trial_id text,
-  PRIMARY KEY ((trial_id,experiment_id))
+  PRIMARY KEY ((experiment_id))
 );


### PR DESCRIPTION
Now trial tables use only experiment_id for partitioning, as it didn’t
make sense to use trial_id, as we are not getting more than one line
per trial_id
