### PR TITLE
Fix various static check issues in faban client

### DIFF
--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
@@ -1,11 +1,34 @@
 package cloud.benchflow.faban.client;
 
-import cloud.benchflow.faban.client.commands.*;
-import cloud.benchflow.faban.client.configurations.*;
-import cloud.benchflow.faban.client.exceptions.*;
-import cloud.benchflow.faban.client.responses.*;
+import cloud.benchflow.faban.client.commands.DeployCommand;
+import cloud.benchflow.faban.client.commands.KillCommand;
+import cloud.benchflow.faban.client.commands.PendingCommand;
+import cloud.benchflow.faban.client.commands.ShowLogsCommand;
+import cloud.benchflow.faban.client.commands.StatusCommand;
+import cloud.benchflow.faban.client.commands.SubmitCommand;
+import cloud.benchflow.faban.client.configurations.Configurable;
+import cloud.benchflow.faban.client.configurations.DeployConfig;
+import cloud.benchflow.faban.client.configurations.FabanClientConfig;
+import cloud.benchflow.faban.client.configurations.FabanClientDefaultConfig;
+import cloud.benchflow.faban.client.configurations.ShowLogsConfig;
+import cloud.benchflow.faban.client.configurations.StatusConfig;
+import cloud.benchflow.faban.client.configurations.SubmitConfig;
+import cloud.benchflow.faban.client.exceptions.BenchmarkNameNotFoundException;
+import cloud.benchflow.faban.client.exceptions.ConfigFileNotFoundException;
+import cloud.benchflow.faban.client.exceptions.FabanClientException;
+import cloud.benchflow.faban.client.exceptions.JarFileNotFoundException;
+import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
+import cloud.benchflow.faban.client.responses.DeployStatus;
+import cloud.benchflow.faban.client.responses.RunId;
+import cloud.benchflow.faban.client.responses.RunLogStream;
+import cloud.benchflow.faban.client.responses.RunQueue;
+import cloud.benchflow.faban.client.responses.RunStatus;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
@@ -107,12 +107,6 @@ public class FabanClient extends Configurable<FabanClientConfig> {
     this.deploy(jarFile).handle(handler);
   }
 
-  /**
-   *
-   * @param runId a run id
-   * @return the status of the run
-   * @throws RunIdNotFoundException
-   */
   public RunStatus status(RunId runId) throws FabanClientException, RunIdNotFoundException {
 
     StatusConfig statusConfig = new StatusConfig(runId);

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
@@ -17,295 +17,316 @@ import java.util.function.Function;
 @SuppressWarnings("unused")
 public class FabanClient extends Configurable<FabanClientConfig> {
 
-    private FabanClientConfig defaultConfig = new FabanClientDefaultConfig();
+  private FabanClientConfig defaultConfig = new FabanClientDefaultConfig();
 
-    private FabanClientConfig chooseConfig() {
-        return (config == null) ? defaultConfig : config;
+  private FabanClientConfig chooseConfig() {
+    return (config == null) ? defaultConfig : config;
+  }
+
+  /**
+   * @param jarFile the benchmark to be deployed on the faban harness
+   * @return a response enclosing the status of the operation
+   */
+  public DeployStatus deploy(File jarFile) throws FabanClientException, JarFileNotFoundException {
+
+    String benchmarkName = jarFile.getName();
+    DeployConfig deployConfig = new DeployConfig(jarFile, benchmarkName);
+    DeployCommand deploy = new DeployCommand().withConfig(deployConfig);
+    FabanClientConfig fabanConfig = chooseConfig();
+
+    try (FileInputStream fin = new FileInputStream(jarFile)) {
+
+      return deploy.exec(fabanConfig);
+      //return deploy(fin, jarFile.getName());
+
+    } catch (FileNotFoundException e) {
+      throw new JarFileNotFoundException(
+          "The specified jar file ( " + jarFile.getAbsolutePath() + " could not be found.");
+    } catch (IOException e) {
+      throw new FabanClientException(
+          "An unknow error occurred while processing the driver to deploy. " + "Please try again.",
+          e);
     }
 
-    /**
-     * @param jarFile the benchmark to be deployed on the faban harness
-     * @return a response enclosing the status of the operation
-     */
-    public DeployStatus deploy(File jarFile) throws FabanClientException, JarFileNotFoundException {
+  }
 
-        String benchmarkName = jarFile.getName();
-        DeployConfig deployConfig = new DeployConfig(jarFile, benchmarkName);
-        DeployCommand deploy = new DeployCommand().withConfig(deployConfig);
-        FabanClientConfig fabanConfig = chooseConfig();
+  public <R extends DeployStatus, T> T deploy(File jarFile, String driverName,
+      Function<R, T> handler) throws FabanClientException, JarFileNotFoundException {
+    return this.deploy(jarFile).handle(handler);
+  }
 
-        try(FileInputStream fin = new FileInputStream(jarFile)) {
+  public <R extends DeployStatus> void deploy(File jarFile, String driverName, Consumer<R> handler)
+      throws FabanClientException, JarFileNotFoundException {
+    this.deploy(jarFile).handle(handler);
+  }
 
-            return deploy.exec(fabanConfig);
-            //return deploy(fin, jarFile.getName());
+  /**
+   * @param jarFile the benchmark to be deployed on the faban harness
+   * @param handler a function that receives a {@link DeployStatus} and returns a {@code <T>}
+   * @param <R> the type of the handler input (has to extend {@link DeployStatus})
+   * @param <T> the arbitrary return type
+   * @return an object of type {@code <T>}
+   */
+  public <R extends DeployStatus, T> T deploy(File jarFile, Function<R, T> handler)
+      throws JarFileNotFoundException, FabanClientException {
+    return this.deploy(jarFile).handle(handler);
+  }
 
-        } catch (FileNotFoundException e) {
-            throw new JarFileNotFoundException("The specified jar file ( " +
-                                            jarFile.getAbsolutePath() +
-                                            " could not be found.");
-        } catch (IOException e) {
-            throw new FabanClientException("An unknow error occurred while processing the driver to deploy. " +
-                    "Please try again.", e);
-        }
 
+  /**
+   * @param jarFile the benchmark to be deployed on the faban harness
+   * @param handler a consumer that receives a {@link DeployStatus}
+   * @param <R> the type of the handler input (has to extend {@link DeployStatus})
+   * @throws FabanClientException
+   */
+  public <R extends DeployStatus> void deploy(File jarFile, Consumer<R> handler)
+      throws JarFileNotFoundException, FabanClientException {
+    this.deploy(jarFile).handle(handler);
+  }
+
+  /**
+   *
+   * @param runId a run id
+   * @return the status of the run
+   * @throws RunIdNotFoundException
+   */
+  public RunStatus status(RunId runId) throws FabanClientException, RunIdNotFoundException {
+
+    StatusConfig statusConfig = new StatusConfig(runId);
+    StatusCommand status = new StatusCommand().withConfig(statusConfig);
+    FabanClientConfig fabanConfig = chooseConfig();
+
+    try {
+      return status.exec(fabanConfig);
+    } catch (IOException e) {
+      throw new FabanClientException(
+          "Something went wrong while requesting status with runId" + runId, e);
     }
 
-    public <R extends DeployStatus, T> T deploy(File jarFile, String driverName, Function<R, T> handler) throws FabanClientException, JarFileNotFoundException {
-        return this.deploy(jarFile).handle(handler);
+  }
+
+  /**
+   *
+   * @param runId a run id
+   * @param handler a callback function
+   * @param <R> The input to the {@param handler} function, a run status
+   * @param <T> The return type of the {@param handler} function
+   * @return An instance of {@link T}
+   * @throws FabanClientException
+   * @throws RunIdNotFoundException if passed a non existent run id
+   */
+  public <R extends RunStatus, T> T status(RunId runId, Function<R, T> handler)
+      throws FabanClientException, RunIdNotFoundException {
+    return this.status(runId).handle(handler);
+  }
+
+  /**
+   *
+   * @param runId a run id
+   * @param handler a callback function
+   * @param <R> The input to the {@param handler} consumer, a run status
+   * @throws RunIdNotFoundException
+   */
+  public <R extends RunStatus> void status(RunId runId, Consumer<R> handler)
+      throws FabanClientException, RunIdNotFoundException {
+    this.status(runId).handle(handler);
+  }
+
+  public RunId submit(String benchmarkName, String profile, InputStream configFile)
+      throws FabanClientException, BenchmarkNameNotFoundException {
+
+    SubmitConfig runConfig = new SubmitConfig(benchmarkName, profile, configFile);
+    SubmitCommand submit = new SubmitCommand().withConfig(runConfig);
+    FabanClientConfig fabanConfig = chooseConfig();
+
+    try {
+      return submit.exec(fabanConfig);
+    } catch (IOException e) {
+      throw new FabanClientException("Something went wrong while submitting the run for benchmark "
+          + benchmarkName + " at profile " + profile);
     }
 
-    public <R extends DeployStatus> void deploy(File jarFile, String driverName, Consumer<R> handler) throws FabanClientException, JarFileNotFoundException {
-        this.deploy(jarFile).handle(handler);
+  }
+
+  /**
+   *
+   * @param benchmarkName benchmark shortname
+   * @param profile a profile name
+   * @param configFile a config xml file for the run
+   * @return the run id for the run
+   * @throws ConfigFileNotFoundException
+   * @throws BenchmarkNameNotFoundException
+   */
+  public RunId submit(String benchmarkName, String profile, File configFile)
+      throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
+
+    //if(configFile.exists()) {
+    try (FileInputStream fin = new FileInputStream(configFile)) {
+
+      return submit(benchmarkName, profile, fin);
+
+    } catch (FileNotFoundException e) {
+      throw new ConfigFileNotFoundException(
+          "Configuration file " + configFile.getAbsolutePath() + " could not be found.");
+    } catch (IOException e) {
+      throw new FabanClientException("Something went wrong while submitting the run for benchmark "
+          + benchmarkName + " at profile " + profile);
     }
 
-    /**
-     * @param jarFile the benchmark to be deployed on the faban harness
-     * @param handler a function that receives a {@link DeployStatus} and returns a {@code <T>}
-     * @param <R> the type of the handler input (has to extend {@link DeployStatus})
-     * @param <T> the arbitrary return type
-     * @return an object of type {@code <T>}
-     */
-    public <R extends DeployStatus, T> T deploy(File jarFile, Function<R, T> handler) throws JarFileNotFoundException, FabanClientException  {
-        return this.deploy(jarFile).handle(handler);
+  }
+
+  public <R extends RunId, T> T submit(String benchmarkName, String profile, InputStream configFile,
+      Function<R, T> handler)
+      throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
+    return this.submit(benchmarkName, profile, configFile).handle(handler);
+  }
+
+  public <R extends RunId> void submit(String benchmarkName, String profile, InputStream configFile,
+      Consumer<R> handler)
+      throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
+    this.submit(benchmarkName, profile, configFile).handle(handler);
+  }
+
+  /**
+   *
+   * @param benchmarkName benchmark shortname
+   * @param profile a profile name
+   * @param configFile a config xml file for the run
+   * @param handler a callback function {@link R} -> {@link T}
+   * @param <R> a subclass of {@link RunId}
+   * @param <T> return type of the {@param handler} function
+   * @return the run id for the run
+   * @throws ConfigFileNotFoundException
+   * @throws BenchmarkNameNotFoundException
+   */
+  public <R extends RunId, T> T submit(String benchmarkName, String profile, File configFile,
+      Function<R, T> handler)
+      throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
+    return this.submit(benchmarkName, profile, configFile).handle(handler);
+  }
+
+  /**
+   *
+   * @param benchmarkName benchmark shortname
+   * @param profile a profile name
+   * @param configFile a config xml file
+   * @param handler a callback consumer {@link R} -> void
+   * @param <R> a subclass of {@link RunId}
+   * @throws ConfigFileNotFoundException
+   * @throws BenchmarkNameNotFoundException
+   */
+  public <R extends RunId> void submit(String benchmarkName, String profile, File configFile,
+      Consumer<R> handler)
+      throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
+    this.submit(benchmarkName, profile, configFile).handle(handler);
+  }
+
+  /**
+   *
+   * @param runId a run id
+   * @return status of the kill operation
+   * @throws RunIdNotFoundException
+   */
+  public RunStatus kill(RunId runId) throws FabanClientException, RunIdNotFoundException {
+
+    StatusConfig killConfig = new StatusConfig(runId);
+    KillCommand kill = new KillCommand().withConfig(killConfig);
+    FabanClientConfig fabanConfig = chooseConfig();
+
+    try {
+      return kill.exec(fabanConfig);
+    } catch (IOException e) {
+      throw new FabanClientException("Unexpected IO error while trying to kill " + runId, e);
     }
 
+  }
 
-    /**
-     * @param jarFile the benchmark to be deployed on the faban harness
-     * @param handler a consumer that receives a {@link DeployStatus}
-     * @param <R> the type of the handler input (has to extend {@link DeployStatus})
-     * @throws FabanClientException
-     */
-    public <R extends DeployStatus> void deploy(File jarFile, Consumer<R> handler) throws JarFileNotFoundException, FabanClientException  {
-        this.deploy(jarFile).handle(handler);
+  /**
+   *
+   * @param runId a run id
+   * @param handler a callback function {@link R} -> {@link T}
+   * @param <R> a subclass of {@link RunStatus}
+   * @param <T> return type of {@param handler}
+   * @return an object of type {@link T}
+   * @throws RunIdNotFoundException
+   */
+  public <R extends RunStatus, T> T kill(RunId runId, Function<R, T> handler)
+      throws RunIdNotFoundException, FabanClientException {
+    return this.kill(runId).handle(handler);
+  }
+
+  /**
+   *
+   * @param runId a run id
+   * @param handler a callback consumer {@link R} -> void
+   * @param <R> a subclass of {@link RunStatus}
+   * @throws RunIdNotFoundException
+   */
+  public <R extends RunStatus> void kill(RunId runId, Consumer<R> handler)
+      throws RunIdNotFoundException, FabanClientException {
+    this.kill(runId).handle(handler);
+  }
+
+  /**
+   *
+   * @return a queue of pending run ids
+   */
+  public RunQueue pending() throws FabanClientException {
+
+    PendingCommand pending = new PendingCommand();
+    FabanClientConfig fabanConfig = chooseConfig();
+
+    try {
+      return pending.exec(fabanConfig);
+    } catch (IOException e) {
+      throw new FabanClientException("Unexpected IO error while requesting for pending runs", e);
     }
 
-    /**
-     *
-     * @param runId a run id
-     * @return the status of the run
-     * @throws RunIdNotFoundException
-     */
-    public RunStatus status(RunId runId) throws FabanClientException, RunIdNotFoundException {
+  }
 
-        StatusConfig statusConfig = new StatusConfig(runId);
-        StatusCommand status = new StatusCommand().withConfig(statusConfig);
-        FabanClientConfig fabanConfig = chooseConfig();
+  /**
+   *
+   * @param handler a callback function {@link R} -> {@link T}
+   * @param <R> a subclass of {@link RunStatus}
+   * @param <T> return type of {@param handler}
+   * @return a queue of pending run ids
+   */
+  public <R extends RunQueue, T> T pending(Function<R, T> handler) {
+    return this.pending().handle(handler);
+  }
 
-        try {
-            return status.exec(fabanConfig);
-        } catch (IOException e) {
-            throw new FabanClientException("Something went wrong while requesting status with runId" + runId, e);
-        }
+  /**
+   *
+   * @param handler a callback consumer {@link R} -> void
+   * @param <R> a subclass of {@link RunQueue}
+   */
+  public <R extends RunQueue> void pending(Consumer<R> handler) {
+    this.pending().handle(handler);
+  }
 
+  public RunLogStream showlogs(RunId runId) throws FabanClientException, RunIdNotFoundException {
+
+    ShowLogsConfig logsConfig = new ShowLogsConfig(runId);
+    ShowLogsCommand showlogs = new ShowLogsCommand().withConfig(logsConfig);
+    FabanClientConfig fabanConfig = chooseConfig();
+
+    try {
+      return showlogs.exec(fabanConfig);
+    } catch (IOException e) {
+      throw new FabanClientException(
+          "Something went wrong while retrieving the logs for run " + runId);
     }
 
-    /**
-     *
-     * @param runId a run id
-     * @param handler a callback function
-     * @param <R> The input to the {@param handler} function, a run status
-     * @param <T> The return type of the {@param handler} function
-     * @return An instance of {@link T}
-     * @throws FabanClientException
-     * @throws RunIdNotFoundException if passed a non existent run id
-     */
-    public <R extends RunStatus, T> T status(RunId runId, Function<R, T> handler) throws FabanClientException, RunIdNotFoundException {
-        return this.status(runId).handle(handler);
-    }
+  }
 
-    /**
-     *
-     * @param runId a run id
-     * @param handler a callback function
-     * @param <R> The input to the {@param handler} consumer, a run status
-     * @throws RunIdNotFoundException
-     */
-    public <R extends RunStatus> void status(RunId runId, Consumer<R> handler) throws FabanClientException, RunIdNotFoundException {
-        this.status(runId).handle(handler);
-    }
+  public <R extends RunLogStream, T> T showlogs(RunId runId, Function<R, T> handler)
+      throws FabanClientException, RunIdNotFoundException {
+    return this.showlogs(runId).handle(handler);
+  }
 
-    public RunId submit(String benchmarkName, String profile, InputStream configFile) throws FabanClientException, BenchmarkNameNotFoundException {
-
-        SubmitConfig runConfig = new SubmitConfig(benchmarkName, profile, configFile);
-        SubmitCommand submit = new SubmitCommand().withConfig(runConfig);
-        FabanClientConfig fabanConfig = chooseConfig();
-
-        try {
-            return submit.exec(fabanConfig);
-        } catch (IOException e) {
-            throw new FabanClientException("Something went wrong while submitting the run for benchmark " +
-                                            benchmarkName + " at profile " + profile);
-        }
-
-    }
-
-    /**
-     *
-     * @param benchmarkName benchmark shortname
-     * @param profile a profile name
-     * @param configFile a config xml file for the run
-     * @return the run id for the run
-     * @throws ConfigFileNotFoundException
-     * @throws BenchmarkNameNotFoundException
-     */
-    public RunId submit(String benchmarkName, String profile, File configFile) throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
-
-        //if(configFile.exists()) {
-        try(FileInputStream fin = new FileInputStream(configFile)) {
-
-            return submit(benchmarkName, profile, fin);
-
-        } catch (FileNotFoundException e) {
-            throw new ConfigFileNotFoundException("Configuration file " +
-                                                    configFile.getAbsolutePath() +
-                                                  " could not be found.");
-        } catch (IOException e) {
-            throw new FabanClientException("Something went wrong while submitting the run for benchmark " +
-                    benchmarkName + " at profile " + profile);
-        }
-
-    }
-
-    public <R extends RunId, T> T submit(String benchmarkName, String profile, InputStream configFile, Function<R, T> handler) throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
-        return this.submit(benchmarkName, profile, configFile).handle(handler);
-    }
-
-    public <R extends RunId> void submit(String benchmarkName, String profile, InputStream configFile, Consumer<R> handler) throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
-        this.submit(benchmarkName, profile, configFile).handle(handler);
-    }
-
-    /**
-     *
-     * @param benchmarkName benchmark shortname
-     * @param profile a profile name
-     * @param configFile a config xml file for the run
-     * @param handler a callback function {@link R} -> {@link T}
-     * @param <R> a subclass of {@link RunId}
-     * @param <T> return type of the {@param handler} function
-     * @return the run id for the run
-     * @throws ConfigFileNotFoundException
-     * @throws BenchmarkNameNotFoundException
-     */
-    public <R extends RunId, T> T submit(String benchmarkName, String profile, File configFile, Function<R, T> handler) throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
-        return this.submit(benchmarkName, profile, configFile).handle(handler);
-    }
-
-    /**
-     *
-     * @param benchmarkName benchmark shortname
-     * @param profile a profile name
-     * @param configFile a config xml file
-     * @param handler a callback consumer {@link R} -> void
-     * @param <R> a subclass of {@link RunId}
-     * @throws ConfigFileNotFoundException
-     * @throws BenchmarkNameNotFoundException
-     */
-    public <R extends RunId> void submit(String benchmarkName, String profile, File configFile, Consumer<R> handler) throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
-        this.submit(benchmarkName, profile, configFile).handle(handler);
-    }
-
-    /**
-     *
-     * @param runId a run id
-     * @return status of the kill operation
-     * @throws RunIdNotFoundException
-     */
-    public RunStatus kill(RunId runId) throws FabanClientException, RunIdNotFoundException {
-
-        StatusConfig killConfig = new StatusConfig(runId);
-        KillCommand kill = new KillCommand().withConfig(killConfig);
-        FabanClientConfig fabanConfig = chooseConfig();
-
-        try {
-            return kill.exec(fabanConfig);
-        } catch (IOException e) {
-            throw new FabanClientException("Unexpected IO error while trying to kill " + runId, e);
-        }
-
-    }
-
-    /**
-     *
-     * @param runId a run id
-     * @param handler a callback function {@link R} -> {@link T}
-     * @param <R> a subclass of {@link RunStatus}
-     * @param <T> return type of {@param handler}
-     * @return an object of type {@link T}
-     * @throws RunIdNotFoundException
-     */
-    public <R extends RunStatus, T> T kill(RunId runId, Function<R,T> handler) throws RunIdNotFoundException, FabanClientException {
-        return this.kill(runId).handle(handler);
-    }
-
-    /**
-     *
-     * @param runId a run id
-     * @param handler a callback consumer {@link R} -> void
-     * @param <R> a subclass of {@link RunStatus}
-     * @throws RunIdNotFoundException
-     */
-    public <R extends RunStatus> void kill(RunId runId, Consumer<R> handler) throws RunIdNotFoundException, FabanClientException {
-        this.kill(runId).handle(handler);
-    }
-
-    /**
-     *
-     * @return a queue of pending run ids
-     */
-    public RunQueue pending() throws FabanClientException {
-
-        PendingCommand pending = new PendingCommand();
-        FabanClientConfig fabanConfig = chooseConfig();
-
-        try {
-            return pending.exec(fabanConfig);
-        } catch (IOException e) {
-            throw new FabanClientException("Unexpected IO error while requesting for pending runs", e);
-        }
-
-    }
-
-    /**
-     *
-     * @param handler a callback function {@link R} -> {@link T}
-     * @param <R> a subclass of {@link RunStatus}
-     * @param <T> return type of {@param handler}
-     * @return a queue of pending run ids
-     */
-    public <R extends RunQueue, T> T pending(Function<R,T> handler) {
-        return this.pending().handle(handler);
-    }
-
-    /**
-     *
-     * @param handler a callback consumer {@link R} -> void
-     * @param <R> a subclass of {@link RunQueue}
-     */
-    public <R extends RunQueue> void pending(Consumer<R> handler) {
-        this.pending().handle(handler);
-    }
-
-    public RunLogStream showlogs(RunId runId) throws FabanClientException, RunIdNotFoundException {
-
-        ShowLogsConfig logsConfig = new ShowLogsConfig(runId);
-        ShowLogsCommand showlogs = new ShowLogsCommand().withConfig(logsConfig);
-        FabanClientConfig fabanConfig = chooseConfig();
-
-        try {
-            return showlogs.exec(fabanConfig);
-        } catch (IOException e) {
-            throw new FabanClientException("Something went wrong while retrieving the logs for run " + runId);
-        }
-
-    }
-
-    public <R extends RunLogStream, T> T showlogs(RunId runId, Function<R, T> handler) throws FabanClientException, RunIdNotFoundException {
-        return this.showlogs(runId).handle(handler);
-    }
-
-    public <R extends RunLogStream> void showlogs(RunId runId, Consumer<R> handler) throws FabanClientException, RunIdNotFoundException {
-        this.showlogs(runId).handle(handler);
-    }
+  public <R extends RunLogStream> void showlogs(RunId runId, Consumer<R> handler)
+      throws FabanClientException, RunIdNotFoundException {
+    this.showlogs(runId).handle(handler);
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
@@ -47,6 +47,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
+   * Deploy a Faban benchmark.
    * @param jarFile the benchmark to be deployed on the faban harness
    * @return a response enclosing the status of the operation
    */
@@ -73,17 +74,35 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   }
 
+  /**
+   * Deploy a Faban benchmark, handling the result of the deployment with an handler.
+   * @param jarFile the benchmark to be deployed on the faban harness
+   * @param driverName the name of the driver
+   * @param handler a callback function
+   * @return a response enclosing the status of the operation
+   * @throws FabanClientException when there is an error interacting with faban
+   * @throws JarFileNotFoundException when the benchmark jar is not found
+   */
   public <R extends DeployStatus, T> T deploy(File jarFile, String driverName,
       Function<R, T> handler) throws FabanClientException, JarFileNotFoundException {
     return this.deploy(jarFile).handle(handler);
   }
 
+  /**
+   * Deploy a Faban benchmark, handling the result of the deployment with an handler.
+   * @param jarFile the benchmark to be deployed on the faban harness
+   * @param driverName the name of the driver
+   * @param handler a callback function
+   * @throws FabanClientException when there is an error interacting with faban
+   * @throws JarFileNotFoundException when the benchmark jar is not found
+   */
   public <R extends DeployStatus> void deploy(File jarFile, String driverName, Consumer<R> handler)
       throws FabanClientException, JarFileNotFoundException {
     this.deploy(jarFile).handle(handler);
   }
 
   /**
+   * Deploy a Faban benchmark, handling the result of the deployment with an handler.
    * @param jarFile the benchmark to be deployed on the faban harness
    * @param handler a function that receives a {@link DeployStatus} and returns a {@code <T>}
    * @param <R> the type of the handler input (has to extend {@link DeployStatus})
@@ -97,16 +116,24 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
 
   /**
+   * Deploy a Faban benchmark, handling the result of the deployment with an handler.
    * @param jarFile the benchmark to be deployed on the faban harness
    * @param handler a consumer that receives a {@link DeployStatus}
    * @param <R> the type of the handler input (has to extend {@link DeployStatus})
-   * @throws FabanClientException
+   * @throws FabanClientException when there is an error interacting with faban
    */
   public <R extends DeployStatus> void deploy(File jarFile, Consumer<R> handler)
       throws JarFileNotFoundException, FabanClientException {
     this.deploy(jarFile).handle(handler);
   }
 
+  /**
+   * Get the status of a Faban benchmark.
+   * @param runId a run id
+   * @return a response enclosing the status of the operation
+   * @throws FabanClientException when there is an error interacting with faban
+   * @throws RunIdNotFoundException when the run id is not found
+   */
   public RunStatus status(RunId runId) throws FabanClientException, RunIdNotFoundException {
 
     StatusConfig statusConfig = new StatusConfig(runId);
@@ -123,13 +150,13 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Get the status of a Faban benchmark, handling the result with an handler.
    * @param runId a run id
    * @param handler a callback function
    * @param <R> The input to the {@param handler} function, a run status
    * @param <T> The return type of the {@param handler} function
    * @return An instance of {@link T}
-   * @throws FabanClientException
+   * @throws FabanClientException when there is an error interacting with faban
    * @throws RunIdNotFoundException if passed a non existent run id
    */
   public <R extends RunStatus, T> T status(RunId runId, Function<R, T> handler)
@@ -138,17 +165,26 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Get the status of a Faban benchmark, handling the result with an handler.
    * @param runId a run id
    * @param handler a callback function
    * @param <R> The input to the {@param handler} consumer, a run status
-   * @throws RunIdNotFoundException
+   * @throws RunIdNotFoundException when the run id is not found
    */
   public <R extends RunStatus> void status(RunId runId, Consumer<R> handler)
       throws FabanClientException, RunIdNotFoundException {
     this.status(runId).handle(handler);
   }
 
+  /**
+   * Submit a Faban benchmark.
+   * @param benchmarkName benchmark shortname
+   * @param profile a profile name
+   * @param configFile a config xml file for the run
+   * @return the run id for the run
+   * @throws FabanClientException when there is an error interacting with faban
+   * @throws BenchmarkNameNotFoundException when the benchmark is not found
+   */
   public RunId submit(String benchmarkName, String profile, InputStream configFile)
       throws FabanClientException, BenchmarkNameNotFoundException {
 
@@ -166,13 +202,13 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Submit a Faban benchmark.
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
    * @param configFile a config xml file for the run
    * @return the run id for the run
-   * @throws ConfigFileNotFoundException
-   * @throws BenchmarkNameNotFoundException
+   * @throws ConfigFileNotFoundException when the configuration file is not found
+   * @throws BenchmarkNameNotFoundException when the benchmark is not found
    */
   public RunId submit(String benchmarkName, String profile, File configFile)
       throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
@@ -192,12 +228,33 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   }
 
+  /**
+   * Submit a Faban benchmark, handling the result with an handler.
+   * @param benchmarkName benchmark shortname
+   * @param profile a profile name
+   * @param configFile a config xml file for the run
+   * @param handler a callback function
+   * @return a run id
+   * @throws FabanClientException when there is an error interacting with faban
+   * @throws ConfigFileNotFoundException when the configuration file is not found
+   * @throws BenchmarkNameNotFoundException when the benchmark is not found
+   */
   public <R extends RunId, T> T submit(String benchmarkName, String profile, InputStream configFile,
       Function<R, T> handler)
       throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
     return this.submit(benchmarkName, profile, configFile).handle(handler);
   }
 
+  /**
+   * Submit a Faban benchmark, handling the result with an handler.
+   * @param benchmarkName benchmark shortname
+   * @param profile a profile name
+   * @param configFile a config xml file for the run
+   * @param handler a callback function
+   * @throws FabanClientException when there is an error interacting with faban
+   * @throws ConfigFileNotFoundException when the configuration file is not found
+   * @throws BenchmarkNameNotFoundException when the benchmark is not found
+   */
   public <R extends RunId> void submit(String benchmarkName, String profile, InputStream configFile,
       Consumer<R> handler)
       throws FabanClientException, ConfigFileNotFoundException, BenchmarkNameNotFoundException {
@@ -205,7 +262,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Submit a Faban benchmark, handling the result with an handler.
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
    * @param configFile a config xml file for the run
@@ -213,8 +270,8 @@ public class FabanClient extends Configurable<FabanClientConfig> {
    * @param <R> a subclass of {@link RunId}
    * @param <T> return type of the {@param handler} function
    * @return the run id for the run
-   * @throws ConfigFileNotFoundException
-   * @throws BenchmarkNameNotFoundException
+   * @throws ConfigFileNotFoundException when the configuration file is not found
+   * @throws BenchmarkNameNotFoundException when the benchmark is not found
    */
   public <R extends RunId, T> T submit(String benchmarkName, String profile, File configFile,
       Function<R, T> handler)
@@ -223,14 +280,14 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Submit a Faban benchmark, handling the result with an handler.
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
    * @param configFile a config xml file
    * @param handler a callback consumer {@link R} -> void
    * @param <R> a subclass of {@link RunId}
-   * @throws ConfigFileNotFoundException
-   * @throws BenchmarkNameNotFoundException
+   * @throws ConfigFileNotFoundException when the configuration file is not found
+   * @throws BenchmarkNameNotFoundException when the benchmark is not found
    */
   public <R extends RunId> void submit(String benchmarkName, String profile, File configFile,
       Consumer<R> handler)
@@ -239,10 +296,10 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Kill a running Faban benchmark.
    * @param runId a run id
    * @return status of the kill operation
-   * @throws RunIdNotFoundException
+   * @throws RunIdNotFoundException when the run id is not found
    */
   public RunStatus kill(RunId runId) throws FabanClientException, RunIdNotFoundException {
 
@@ -259,13 +316,13 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Kill a running Faban benchmark, handling the result with an handler.
    * @param runId a run id
    * @param handler a callback function {@link R} -> {@link T}
    * @param <R> a subclass of {@link RunStatus}
    * @param <T> return type of {@param handler}
    * @return an object of type {@link T}
-   * @throws RunIdNotFoundException
+   * @throws RunIdNotFoundException when the run id is not found
    */
   public <R extends RunStatus, T> T kill(RunId runId, Function<R, T> handler)
       throws RunIdNotFoundException, FabanClientException {
@@ -273,11 +330,11 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Kill a running Faban benchmark, handling the result with an handler.
    * @param runId a run id
    * @param handler a callback consumer {@link R} -> void
    * @param <R> a subclass of {@link RunStatus}
-   * @throws RunIdNotFoundException
+   * @throws RunIdNotFoundException when the run id is not found
    */
   public <R extends RunStatus> void kill(RunId runId, Consumer<R> handler)
       throws RunIdNotFoundException, FabanClientException {
@@ -285,7 +342,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Return the list of pending benchmarks.
    * @return a queue of pending run ids
    */
   public RunQueue pending() throws FabanClientException {
@@ -302,7 +359,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Return the list of pending benchmarks, handling the result with an handler.
    * @param handler a callback function {@link R} -> {@link T}
    * @param <R> a subclass of {@link RunStatus}
    * @param <T> return type of {@param handler}
@@ -313,7 +370,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   *
+   * Return the list of pending benchmarks, handling the result with an handler.
    * @param handler a callback consumer {@link R} -> void
    * @param <R> a subclass of {@link RunQueue}
    */
@@ -321,6 +378,13 @@ public class FabanClient extends Configurable<FabanClientConfig> {
     this.pending().handle(handler);
   }
 
+  /**
+   * Show the logs of a running benchmark.
+   * @param runId the run id for the run
+   * @return a LogStream
+   * @throws FabanClientException when there is an error interacting with faban
+   * @throws RunIdNotFoundException when the run id is not found
+   */
   public RunLogStream showlogs(RunId runId) throws FabanClientException, RunIdNotFoundException {
 
     ShowLogsConfig logsConfig = new ShowLogsConfig(runId);
@@ -336,11 +400,26 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   }
 
+  /**
+   * Show the logs of a running benchmark, handling the result with an handler.
+   * @param runId the run id for the run
+   * @param handler a callback function
+   * @return a LogStream
+   * @throws FabanClientException when there is an error interacting with faban
+   * @throws RunIdNotFoundException when the run id is not found
+   */
   public <R extends RunLogStream, T> T showlogs(RunId runId, Function<R, T> handler)
       throws FabanClientException, RunIdNotFoundException {
     return this.showlogs(runId).handle(handler);
   }
 
+  /**
+   * Show the logs of a running benchmark, handling the result with an handler.
+   * @param runId the run id for the run
+   * @param handler a callback function
+   * @throws FabanClientException when there is an error interacting with faban
+   * @throws RunIdNotFoundException when the run id is not found
+   */
   public <R extends RunLogStream> void showlogs(RunId runId, Consumer<R> handler)
       throws FabanClientException, RunIdNotFoundException {
     this.showlogs(runId).handle(handler);

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
@@ -33,9 +33,9 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
  * The faban client implementation.
+ * 
+ * @author Simone D'Avico (simonedavico@gmail.com)
  */
 @SuppressWarnings("unused")
 public class FabanClient extends Configurable<FabanClientConfig> {

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/Command.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/Command.java
@@ -5,9 +5,9 @@ import cloud.benchflow.faban.client.responses.Response;
 
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
  * Interface for a generic command.
+ * 
+ * @author Simone D'Avico (simonedavico@gmail.com)
  */
 public interface Command<T extends Response> {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/Command.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/Command.java
@@ -11,8 +11,8 @@ import cloud.benchflow.faban.client.responses.Response;
  */
 public interface Command<T extends Response> {
 
-    default T exec(FabanClientConfig fabanConfig) throws Exception {
-        throw new UnsupportedOperationException();
-    }
+  default T exec(FabanClientConfig fabanConfig) throws Exception {
+    throw new UnsupportedOperationException();
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
@@ -1,35 +1,24 @@
 package cloud.benchflow.faban.client.commands;
 
+import cloud.benchflow.faban.client.configurations.Configurable;
 import cloud.benchflow.faban.client.configurations.DeployConfig;
 import cloud.benchflow.faban.client.configurations.FabanClientConfig;
-import cloud.benchflow.faban.client.responses.DeployStatus;
-import cloud.benchflow.faban.client.configurations.Configurable;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
-import com.google.common.io.ByteStreams;
-import org.apache.http.HttpEntity;
+import cloud.benchflow.faban.client.responses.DeployStatus;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.http.HttpEntity;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ContentType;
-import org.apache.http.entity.mime.FormBodyPart;
-import org.apache.http.entity.mime.FormBodyPartBuilder;
-import org.apache.http.entity.mime.MIME;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
-import org.apache.http.entity.mime.content.ByteArrayBody;
-import org.apache.http.entity.mime.content.ContentBody;
-import org.apache.http.entity.mime.content.FileBody;
-import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Arrays;
 
 
 /**

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
@@ -37,66 +37,61 @@ import java.util.Arrays;
  *
  * Created on 26/10/15.
  */
-public class DeployCommand extends Configurable<DeployConfig> implements Command<DeployStatus>  {
+public class DeployCommand extends Configurable<DeployConfig> implements Command<DeployStatus> {
 
-    private static String DEPLOY_URL = "/deploy";
+  private static String DEPLOY_URL = "/deploy";
 
-    /**
-     *
-     * @param fabanConfig the harness configuration
-     * @return a response containing the status of the operation
-     * @throws IOException
-     */
-    public DeployStatus exec(FabanClientConfig fabanConfig)  throws IOException {
-        return deploy(fabanConfig);
+  /**
+   *
+   * @param fabanConfig the harness configuration
+   * @return a response containing the status of the operation
+   * @throws IOException
+   */
+  public DeployStatus exec(FabanClientConfig fabanConfig) throws IOException {
+    return deploy(fabanConfig);
+  }
+
+
+  /*  Since deploying a stream to Faban suddenly doesn’t work anymore, we
+      changed the API to deploy a File (which works as expected).
+  
+      A stream would have been better because it wouldn’t have required to
+      have a file on the file system, reducing the IO of the components using
+      the library.
+      Nevertheless, this solution is good enough until we figure out how to
+      send a stream of data to Faban. */
+  private DeployStatus deploy(FabanClientConfig fabanConfig) throws IOException {
+
+    ResponseHandler<DeployStatus> dh = resp -> {
+      System.out.println(resp);
+      return new DeployStatus(resp.getStatusLine().getStatusCode());
+    };
+
+    File jarFile = this.config.getJarFile();
+    Boolean clearConfig = config.clearConfig();
+
+    try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+
+      URI deployURL = new URIBuilder(fabanConfig.getMasterURL()).setPath(DEPLOY_URL).build();
+      HttpPost post = new HttpPost(deployURL);
+
+      HttpEntity multipartEntity = MultipartEntityBuilder.create()
+          .addTextBody("user", fabanConfig.getUser())
+          .addTextBody("password", fabanConfig.getPassword()).addBinaryBody("jarfile", jarFile,
+              ContentType.create("application/java-archive"), config.getDriverName())
+          .addTextBody("clearconfig", clearConfig.toString()).build();
+
+      post.setEntity(multipartEntity);
+      post.setHeader("Accept", "text/plain");
+
+      DeployStatus dresp = httpclient.execute(post, dh);
+
+      return dresp;
+
+    } catch (URISyntaxException e) { //this should never occur
+      throw new MalformedURIException("Attempted to deploy to malformed URI: " + e.getInput(), e);
     }
 
-
-    /*  Since deploying a stream to Faban suddenly doesn’t work anymore, we
-        changed the API to deploy a File (which works as expected).
-
-        A stream would have been better because it wouldn’t have required to
-        have a file on the file system, reducing the IO of the components using
-        the library.
-        Nevertheless, this solution is good enough until we figure out how to
-        send a stream of data to Faban. */
-    private DeployStatus deploy(FabanClientConfig fabanConfig) throws IOException {
-
-        ResponseHandler<DeployStatus> dh = resp -> {
-          System.out.println(resp);
-          return new DeployStatus(resp.getStatusLine().getStatusCode());
-        };
-
-        File jarFile = this.config.getJarFile();
-        Boolean clearConfig = config.clearConfig();
-
-        try (CloseableHttpClient httpclient = HttpClients.createDefault()){
-
-            URI deployURL = new URIBuilder(fabanConfig.getMasterURL())
-                                .setPath(DEPLOY_URL)
-                                .build();
-            HttpPost post = new HttpPost(deployURL);
-
-            HttpEntity multipartEntity = MultipartEntityBuilder
-                    .create()
-                    .addTextBody("user", fabanConfig.getUser())
-                    .addTextBody("password", fabanConfig.getPassword())
-                    .addBinaryBody("jarfile", jarFile,
-                                    ContentType.create("application/java-archive"), config.getDriverName())
-                    .addTextBody("clearconfig", clearConfig.toString())
-                    .build();
-
-            post.setEntity(multipartEntity);
-            post.setHeader("Accept", "text/plain");
-
-            DeployStatus dresp = httpclient.execute(post, dh);
-
-            return dresp;
-
-        } catch (URISyntaxException e) { //this should never occur
-            throw new MalformedURIException("Attempted to deploy to malformed URI: " + e.getInput(), e);
-        }
-
-    }
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
@@ -29,10 +29,10 @@ public class DeployCommand extends Configurable<DeployConfig> implements Command
   private static String DEPLOY_URL = "/deploy";
 
   /**
-   *
+   * Deploy a Faban benchmark.
    * @param fabanConfig the harness configuration
    * @return a response containing the status of the operation
-   * @throws IOException
+   * @throws IOException when there are issues in reading the benchmark file
    */
   public DeployStatus exec(FabanClientConfig fabanConfig) throws IOException {
     return deploy(fabanConfig);

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
@@ -22,9 +22,7 @@ import org.apache.http.impl.client.HttpClients;
 
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 26/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 26/10/15.
  */
 public class DeployCommand extends Configurable<DeployConfig> implements Command<DeployStatus> {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
@@ -9,6 +9,13 @@ import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
 import cloud.benchflow.faban.client.responses.RunId;
 import cloud.benchflow.faban.client.responses.RunStatus;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.ResponseHandler;
@@ -20,12 +27,6 @@ import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author Simone D'Avico <simonedavico@gmail.com>

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
@@ -21,8 +21,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 
-
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -36,46 +34,48 @@ import java.util.List;
  */
 public class KillCommand extends Configurable<StatusConfig> implements Command<RunStatus> {
 
-    private static String KILL_URL = "/kill";
+  private static String KILL_URL = "/kill";
 
-    public RunStatus exec(FabanClientConfig fabanConfig) throws RunIdNotFoundException, IOException {
-        return kill(fabanConfig);
+  public RunStatus exec(FabanClientConfig fabanConfig) throws RunIdNotFoundException, IOException {
+    return kill(fabanConfig);
+  }
+
+  private RunStatus kill(FabanClientConfig fabanConfig) throws RunIdNotFoundException, IOException {
+
+    RunId runId = config.getRunId();
+
+    ResponseHandler<RunStatus> rh =
+        resp -> new RunStatus(new BasicResponseHandler().handleEntity(resp.getEntity()), runId);
+
+    try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+
+      URI killURL =
+          new URIBuilder(fabanConfig.getMasterURL()).setPath(KILL_URL + "/" + runId).build();
+
+      //TODO: check that this setup creates the correct request
+      List<NameValuePair> params = new ArrayList<>();
+      params.add(new BasicNameValuePair("sun", fabanConfig.getUser()));
+      params.add(new BasicNameValuePair("sp", fabanConfig.getPassword()));
+
+      HttpPost post = new HttpPost(killURL);
+      post.setEntity(new UrlEncodedFormEntity(params));
+
+      CloseableHttpResponse resp = httpClient.execute(post);
+
+      int statusCode = resp.getStatusLine().getStatusCode();
+      if (statusCode == HttpStatus.SC_NOT_FOUND)
+        throw new RunIdNotFoundException();
+      if (statusCode == HttpStatus.SC_BAD_REQUEST)
+        throw new FabanClientException("Bad kill request to harness");
+      if (statusCode == HttpStatus.SC_NO_CONTENT)
+        throw new EmptyHarnessResponseException();
+
+      return rh.handleResponse(resp);
+
+    } catch (URISyntaxException e) {
+      throw new MalformedURIException("Attempted to kill to malformed URI " + e.getInput(), e);
     }
 
-    private RunStatus kill(FabanClientConfig fabanConfig) throws RunIdNotFoundException, IOException {
-
-        RunId runId = config.getRunId();
-
-        ResponseHandler<RunStatus> rh = resp ->
-                new RunStatus(new BasicResponseHandler().handleEntity(resp.getEntity()), runId);
-
-        try(CloseableHttpClient httpClient = HttpClients.createDefault()) {
-
-            URI killURL = new URIBuilder(fabanConfig.getMasterURL())
-                                .setPath(KILL_URL + "/" + runId)
-                                .build();
-
-            //TODO: check that this setup creates the correct request
-            List<NameValuePair> params = new ArrayList<>();
-            params.add(new BasicNameValuePair("sun", fabanConfig.getUser()));
-            params.add(new BasicNameValuePair("sp", fabanConfig.getPassword()));
-
-            HttpPost post = new HttpPost(killURL);
-            post.setEntity(new UrlEncodedFormEntity(params));
-
-            CloseableHttpResponse resp = httpClient.execute(post);
-
-            int statusCode = resp.getStatusLine().getStatusCode();
-            if(statusCode == HttpStatus.SC_NOT_FOUND) throw new RunIdNotFoundException();
-            if(statusCode == HttpStatus.SC_BAD_REQUEST) throw new FabanClientException("Bad kill request to harness");
-            if(statusCode == HttpStatus.SC_NO_CONTENT) throw new EmptyHarnessResponseException();
-
-            return rh.handleResponse(resp);
-
-        } catch (URISyntaxException e) {
-            throw new MalformedURIException("Attempted to kill to malformed URI " + e.getInput(), e);
-        }
-
-    }
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
@@ -64,12 +64,13 @@ public class KillCommand extends Configurable<StatusConfig> implements Command<R
       CloseableHttpResponse resp = httpClient.execute(post);
 
       int statusCode = resp.getStatusLine().getStatusCode();
-      if (statusCode == HttpStatus.SC_NOT_FOUND)
+      if (statusCode == HttpStatus.SC_NOT_FOUND) {
         throw new RunIdNotFoundException();
-      if (statusCode == HttpStatus.SC_BAD_REQUEST)
+      } else if (statusCode == HttpStatus.SC_BAD_REQUEST) {
         throw new FabanClientException("Bad kill request to harness");
-      if (statusCode == HttpStatus.SC_NO_CONTENT)
+      } else if (statusCode == HttpStatus.SC_NO_CONTENT) {
         throw new EmptyHarnessResponseException();
+      }
 
       return rh.handleResponse(resp);
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
@@ -29,9 +29,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 29/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 29/10/15.
  */
 public class KillCommand extends Configurable<StatusConfig> implements Command<RunStatus> {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/PendingCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/PendingCommand.java
@@ -7,6 +7,13 @@ import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.responses.RunId;
 import cloud.benchflow.faban.client.responses.RunQueue;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -14,13 +21,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 
 /**

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/PendingCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/PendingCommand.java
@@ -48,9 +48,10 @@ public class PendingCommand extends Configurable implements Command<RunQueue> {
       CloseableHttpResponse resp = httpClient.execute(get);
       int status = resp.getStatusLine().getStatusCode();
 
-      if (status == HttpStatus.SC_NO_CONTENT)
+      if (status == HttpStatus.SC_NO_CONTENT) {
         throw new EmptyHarnessResponseException(
             "Harness returned empty response to pending request");
+      }
 
       HttpEntity ent = resp.getEntity();
       InputStream in = resp.getEntity().getContent();

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/PendingCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/PendingCommand.java
@@ -24,9 +24,7 @@ import org.apache.http.impl.client.HttpClients;
 
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 30/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 30/10/15.
  */
 public class PendingCommand extends Configurable implements Command<RunQueue> {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/PendingCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/PendingCommand.java
@@ -30,48 +30,48 @@ import java.net.URISyntaxException;
  */
 public class PendingCommand extends Configurable implements Command<RunQueue> {
 
-    private static String PENDING_URL = "/pending";
+  private static String PENDING_URL = "/pending";
 
-    public RunQueue exec(FabanClientConfig fabanConfig) throws IOException {
-        return pending(fabanConfig);
-    }
+  public RunQueue exec(FabanClientConfig fabanConfig) throws IOException {
+    return pending(fabanConfig);
+  }
 
-    private RunQueue pending(FabanClientConfig fabanConfig) throws IOException {
+  private RunQueue pending(FabanClientConfig fabanConfig) throws IOException {
 
-        try(CloseableHttpClient httpClient = HttpClients.createDefault()){
+    try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
 
-            URI pendingURL = new URIBuilder(fabanConfig.getMasterURL())
-                                .setPath(PENDING_URL)
-                                .build();
+      URI pendingURL = new URIBuilder(fabanConfig.getMasterURL()).setPath(PENDING_URL).build();
 
-            RunQueue queue = new RunQueue();
+      RunQueue queue = new RunQueue();
 
-            HttpGet get = new HttpGet(pendingURL);
-            CloseableHttpResponse resp = httpClient.execute(get);
-            int status = resp.getStatusLine().getStatusCode();
+      HttpGet get = new HttpGet(pendingURL);
+      CloseableHttpResponse resp = httpClient.execute(get);
+      int status = resp.getStatusLine().getStatusCode();
 
-            if(status == HttpStatus.SC_NO_CONTENT)
-                throw new EmptyHarnessResponseException("Harness returned empty response to pending request");
+      if (status == HttpStatus.SC_NO_CONTENT)
+        throw new EmptyHarnessResponseException(
+            "Harness returned empty response to pending request");
 
-            HttpEntity ent = resp.getEntity();
-            InputStream in = resp.getEntity().getContent();
+      HttpEntity ent = resp.getEntity();
+      InputStream in = resp.getEntity().getContent();
 
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(in, ent.getContentEncoding().getValue()))) {
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(in, ent.getContentEncoding().getValue()))) {
 
-                String line;
-                while((line = reader.readLine()) != null) {
-                    queue.add(new RunId(line));
-                }
-
-            }
-
-            return queue;
-
-        } catch (URISyntaxException e) {
-            throw new MalformedURIException("Malformed pending request to faban harness: " + e.getInput(), e);
+        String line;
+        while ((line = reader.readLine()) != null) {
+          queue.add(new RunId(line));
         }
 
+      }
+
+      return queue;
+
+    } catch (URISyntaxException e) {
+      throw new MalformedURIException("Malformed pending request to faban harness: " + e.getInput(),
+          e);
     }
+
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/ShowLogsCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/ShowLogsCommand.java
@@ -7,13 +7,6 @@ import cloud.benchflow.faban.client.exceptions.EmptyHarnessResponseException;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
 import cloud.benchflow.faban.client.responses.RunLogStream;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -21,6 +14,14 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 
 /**
  * @author Simone D'Avico <simonedavico@gmail.com>

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/ShowLogsCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/ShowLogsCommand.java
@@ -50,11 +50,12 @@ public class ShowLogsCommand extends Configurable<ShowLogsConfig> implements Com
       CloseableHttpResponse resp = httpClient.execute(get);
       int status = resp.getStatusLine().getStatusCode();
 
-      if (status == HttpStatus.SC_NO_CONTENT)
+      if (status == HttpStatus.SC_NO_CONTENT) {
         throw new EmptyHarnessResponseException(
             "Harness returned empty response to pending request");
-      if (status == HttpStatus.SC_NOT_FOUND)
+      } else if (status == HttpStatus.SC_NOT_FOUND) {
         throw new RunIdNotFoundException();
+      }
 
       HttpEntity ent = resp.getEntity();
       InputStream in = resp.getEntity().getContent();

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/ShowLogsCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/ShowLogsCommand.java
@@ -24,9 +24,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 11/11/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 11/11/15.
  */
 public class ShowLogsCommand extends Configurable<ShowLogsConfig> implements Command<RunLogStream> {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/StatusCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/StatusCommand.java
@@ -1,13 +1,17 @@
 package cloud.benchflow.faban.client.commands;
 
-import cloud.benchflow.faban.client.configurations.FabanClientConfig;
-import cloud.benchflow.faban.client.responses.RunStatus;
 import cloud.benchflow.faban.client.configurations.Configurable;
+import cloud.benchflow.faban.client.configurations.FabanClientConfig;
 import cloud.benchflow.faban.client.configurations.StatusConfig;
 import cloud.benchflow.faban.client.exceptions.FabanClientException;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
 import cloud.benchflow.faban.client.responses.RunId;
+import cloud.benchflow.faban.client.responses.RunStatus;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.ResponseHandler;
@@ -17,10 +21,6 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 /**
  * @author Simone D'Avico <simonedavico@gmail.com>

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/StatusCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/StatusCommand.java
@@ -23,9 +23,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 28/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 28/10/15.
  */
 public class StatusCommand extends Configurable<StatusConfig> implements Command<RunStatus> {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/StatusCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/StatusCommand.java
@@ -53,10 +53,11 @@ public class StatusCommand extends Configurable<StatusConfig> implements Command
       CloseableHttpResponse resp = httpclient.execute(get);
 
       int status = resp.getStatusLine().getStatusCode();
-      if (status == HttpStatus.SC_NOT_FOUND)
+      if (status == HttpStatus.SC_NOT_FOUND) {
         throw new RunIdNotFoundException();
-      if (status == HttpStatus.SC_BAD_REQUEST)
+      } else if (status == HttpStatus.SC_BAD_REQUEST) {
         throw new FabanClientException("Illegal status request");
+      }
 
       //TODO: check that the call to .handleEntity(..) actually returns the expected string
       RunStatus runStatus = sh.handleResponse(resp);

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
@@ -28,9 +28,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 28/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 28/10/15.
  */
 public class SubmitCommand extends Configurable<SubmitConfig> implements Command<RunId> {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
@@ -1,15 +1,23 @@
 package cloud.benchflow.faban.client.commands;
 
+import cloud.benchflow.faban.client.configurations.Configurable;
 import cloud.benchflow.faban.client.configurations.FabanClientConfig;
 import cloud.benchflow.faban.client.configurations.SubmitConfig;
 import cloud.benchflow.faban.client.exceptions.BenchmarkNameNotFoundException;
 import cloud.benchflow.faban.client.exceptions.EmptyHarnessResponseException;
-import cloud.benchflow.faban.client.configurations.Configurable;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.responses.RunId;
+
 import com.google.common.io.ByteStreams;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
+import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
@@ -18,12 +26,6 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.client.ResponseHandler;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 /**
  * @author Simone D'Avico <simonedavico@gmail.com>

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
@@ -69,10 +69,11 @@ public class SubmitCommand extends Configurable<SubmitConfig> implements Command
 
       CloseableHttpResponse resp = httpClient.execute(post);
       int statusCode = resp.getStatusLine().getStatusCode();
-      if (statusCode == HttpStatus.SC_NOT_FOUND)
+      if (statusCode == HttpStatus.SC_NOT_FOUND) {
         throw new BenchmarkNameNotFoundException("Benchmark " + benchmarkName + " not deployed.");
-      if (statusCode == HttpStatus.SC_NO_CONTENT)
+      } else if (statusCode == HttpStatus.SC_NO_CONTENT) {
         throw new EmptyHarnessResponseException();
+      }
 
       //TODO: check that this does indeed work
       RunId runId = sh.handleResponse(resp);

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
@@ -39,6 +39,13 @@ public class SubmitCommand extends Configurable<SubmitConfig> implements Command
     return submit(fabanConfig);
   }
 
+  /**
+   * Run a Faban benchmark.
+   * @param fabanConfig the harness configuration
+   * @return a response containing the status of the operation
+   * @throws IOException when there are issues in reading the benchmark file
+   * @throws BenchmarkNameNotFoundException when the requested benchmark is not found
+   */
   public RunId submit(FabanClientConfig fabanConfig)
       throws IOException, BenchmarkNameNotFoundException {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/Config.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/Config.java
@@ -1,9 +1,7 @@
 package cloud.benchflow.faban.client.configurations;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 26/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 26/10/15.
  */
 public interface Config {
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/Configurable.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/Configurable.java
@@ -9,11 +9,11 @@ package cloud.benchflow.faban.client.configurations;
 @SuppressWarnings("unchecked")
 public abstract class Configurable<U extends Config> {
 
-    protected U config;
+  protected U config;
 
-    public <T extends Configurable> T withConfig(U config) {
-        this.config = config;
-        return (T) this;
-    }
+  public <T extends Configurable> T withConfig(U config) {
+    this.config = config;
+    return (T) this;
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/Configurable.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/Configurable.java
@@ -1,10 +1,9 @@
 package cloud.benchflow.faban.client.configurations;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- * Created on 26/10/15.
- *
  * An abstract class representing a configurable object.
+ * 
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 26/10/15.
  */
 @SuppressWarnings("unchecked")
 public abstract class Configurable<U extends Config> {

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
@@ -4,8 +4,8 @@ import java.io.File;
 
 /**
  * Created by simonedavico on 26/10/15.
- *
- * Configuration class for the deploy command
+ * 
+ * <p>Configuration class for the deploy command
  */
 public class DeployConfig implements Config {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
@@ -14,10 +14,22 @@ public class DeployConfig implements Config {
   private String driverName;
   private boolean clearConfig;
 
+  /**
+   * Construct a DeployConfig from the benchmark file and a name for the driver.
+   * @param jarFile the benchmark file
+   * @param driverName the driver name
+   */
   public DeployConfig(File jarFile, String driverName) {
     this(jarFile, driverName, true);
   }
 
+  /**
+   * Construct a DeployConfig from the benchmark file and a name for the driver,
+   * clearing the previous configuration for the benchmark.
+   * @param jarFile the benchmark file
+   * @param driverName the driver name
+   * @param clearConfig true for clearing the previous configuration for the benchmark
+   */
   public DeployConfig(File jarFile, String driverName, boolean clearConfig) {
     this.jarFile = jarFile;
     this.driverName = driverName;

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
@@ -1,7 +1,6 @@
 package cloud.benchflow.faban.client.configurations;
 
 import java.io.File;
-import java.io.InputStream;
 
 /**
  * Created by simonedavico on 26/10/15.

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
@@ -10,28 +10,30 @@ import java.io.InputStream;
  */
 public class DeployConfig implements Config {
 
-    private File jarFile;
-//    private InputStream jarFile;
-    private String driverName;
-    private boolean clearConfig;
+  private File jarFile;
+  //    private InputStream jarFile;
+  private String driverName;
+  private boolean clearConfig;
 
-    public DeployConfig(File jarFile, String driverName) {
-        this(jarFile, driverName, true);
-    }
+  public DeployConfig(File jarFile, String driverName) {
+    this(jarFile, driverName, true);
+  }
 
-    public DeployConfig(File jarFile, String driverName, boolean clearConfig) {
-        this.jarFile = jarFile;
-        this.driverName = driverName;
-        this.clearConfig = clearConfig;
-    }
+  public DeployConfig(File jarFile, String driverName, boolean clearConfig) {
+    this.jarFile = jarFile;
+    this.driverName = driverName;
+    this.clearConfig = clearConfig;
+  }
 
-    public File getJarFile() {
-        return jarFile;
-    }
+  public File getJarFile() {
+    return jarFile;
+  }
 
-    public boolean clearConfig() {
-        return clearConfig;
-    }
+  public boolean clearConfig() {
+    return clearConfig;
+  }
 
-    public String getDriverName() { return driverName; }
+  public String getDriverName() {
+    return driverName;
+  }
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfig.java
@@ -7,9 +7,9 @@ import java.net.URI;
  */
 public interface FabanClientConfig extends Config {
 
-    String getUser();
+  String getUser();
 
-    String getPassword();
+  String getPassword();
 
-    URI getMasterURL();
+  URI getMasterURL();
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfigImpl.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfigImpl.java
@@ -15,10 +15,21 @@ public class FabanClientConfigImpl implements FabanClientConfig {
   private final String password;
   private final URI masterURL;
 
+  /**
+   * Creates a FabanClientConfigImpl on the default url.
+   * @param user Faban harness username
+   * @param password Faban harness password
+   */
   public FabanClientConfigImpl(final String user, final String password) {
     this(user, password, new FabanClientDefaultConfig().getMasterURL());
   }
 
+  /**
+   * Creates a FabanClientConfigImpl on a custom url.
+   * @param user Faban harness username
+   * @param password Faban harness password
+   * @param masterURL Faban harness url
+   */
   public FabanClientConfigImpl(final String user, final String password, final URI masterURL) {
     this.user = user;
     this.password = password;

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfigImpl.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfigImpl.java
@@ -3,12 +3,11 @@ package cloud.benchflow.faban.client.configurations;
 import java.net.URI;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
  * A configuration class for the faban client.
  * The user can configure username and password,
  * or username, password and masterURL.
  *
+ * @author Simone D'Avico (simonedavico@gmail.com)
  */
 public class FabanClientConfigImpl implements FabanClientConfig {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfigImpl.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfigImpl.java
@@ -12,30 +12,30 @@ import java.net.URI;
  */
 public class FabanClientConfigImpl implements FabanClientConfig {
 
-    private final String user;
-    private final String password;
-    private final URI masterURL;
+  private final String user;
+  private final String password;
+  private final URI masterURL;
 
-    public FabanClientConfigImpl(final String user, final String password) {
-        this(user, password, new FabanClientDefaultConfig().getMasterURL());
-    }
+  public FabanClientConfigImpl(final String user, final String password) {
+    this(user, password, new FabanClientDefaultConfig().getMasterURL());
+  }
 
-    public FabanClientConfigImpl(final String user, final String password, final URI masterURL) {
-        this.user = user;
-        this.password = password;
-        this.masterURL = masterURL;
-    }
+  public FabanClientConfigImpl(final String user, final String password, final URI masterURL) {
+    this.user = user;
+    this.password = password;
+    this.masterURL = masterURL;
+  }
 
 
-    public String getUser() {
-        return user;
-    }
+  public String getUser() {
+    return user;
+  }
 
-    public String getPassword() {
-        return password;
-    }
+  public String getPassword() {
+    return password;
+  }
 
-    public URI getMasterURL() {
-        return masterURL;
-    }
+  public URI getMasterURL() {
+    return masterURL;
+  }
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientDefaultConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientDefaultConfig.java
@@ -12,6 +12,9 @@ public class FabanClientDefaultConfig implements FabanClientConfig {
 
   private FabanClientConfigImpl defaultConfig;
 
+  /**
+   * Default constructor for the FabanClientDefaultConfig.
+   */
   public FabanClientDefaultConfig() {
 
     FabanClientConfigImpl defConf = null;

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientDefaultConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientDefaultConfig.java
@@ -6,7 +6,7 @@ import java.net.URISyntaxException;
 /**
  * Created by simonedavico on 26/10/15.
  *
- * Default configuration for the Faban client.
+ * <p>Default configuration for the Faban client.
  */
 public class FabanClientDefaultConfig implements FabanClientConfig {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientDefaultConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientDefaultConfig.java
@@ -10,32 +10,32 @@ import java.net.URISyntaxException;
  */
 public class FabanClientDefaultConfig implements FabanClientConfig {
 
-    private FabanClientConfigImpl defaultConfig;
+  private FabanClientConfigImpl defaultConfig;
 
-    public FabanClientDefaultConfig() {
+  public FabanClientDefaultConfig() {
 
-        FabanClientConfigImpl defConf = null;
-        try {
-            defConf = new FabanClientConfigImpl("deployer", "adminadmin", new URI("http://localhost:9980/"));
-        } catch (URISyntaxException e) {
-            System.err.println("There was a problem initializing the default " +
-                    "faban client configuration. See the stack" +
-                    "trace for more informations.");
-            e.printStackTrace();
-        }
-        this.defaultConfig = defConf;
+    FabanClientConfigImpl defConf = null;
+    try {
+      defConf =
+          new FabanClientConfigImpl("deployer", "adminadmin", new URI("http://localhost:9980/"));
+    } catch (URISyntaxException e) {
+      System.err.println("There was a problem initializing the default "
+          + "faban client configuration. See the stack" + "trace for more informations.");
+      e.printStackTrace();
     }
+    this.defaultConfig = defConf;
+  }
 
-    public String getUser() {
-        return defaultConfig.getUser();
-    }
+  public String getUser() {
+    return defaultConfig.getUser();
+  }
 
-    public String getPassword() {
-        return defaultConfig.getPassword();
-    }
+  public String getPassword() {
+    return defaultConfig.getPassword();
+  }
 
-    public URI getMasterURL() {
-        return defaultConfig.getMasterURL();
-    }
+  public URI getMasterURL() {
+    return defaultConfig.getMasterURL();
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/ShowLogsConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/ShowLogsConfig.java
@@ -3,9 +3,7 @@ package cloud.benchflow.faban.client.configurations;
 import cloud.benchflow.faban.client.responses.RunId;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 11/11/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 11/11/15.
  */
 //TODO: implement this
 public class ShowLogsConfig implements Config {

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/ShowLogsConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/ShowLogsConfig.java
@@ -10,14 +10,14 @@ import cloud.benchflow.faban.client.responses.RunId;
 //TODO: implement this
 public class ShowLogsConfig implements Config {
 
-    private RunId runId;
+  private RunId runId;
 
-    public ShowLogsConfig(RunId runId) {
-        this.runId = runId;
-    }
+  public ShowLogsConfig(RunId runId) {
+    this.runId = runId;
+  }
 
-    public RunId getRunId() {
-        return runId;
-    }
+  public RunId getRunId() {
+    return runId;
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/StatusConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/StatusConfig.java
@@ -9,14 +9,14 @@ import cloud.benchflow.faban.client.responses.RunId;
  */
 public class StatusConfig implements Config {
 
-    private RunId runId;
+  private RunId runId;
 
-    public StatusConfig(RunId runId) {
-        this.runId = runId;
-    }
+  public StatusConfig(RunId runId) {
+    this.runId = runId;
+  }
 
-    public RunId getRunId() {
-        return runId;
-    }
+  public RunId getRunId() {
+    return runId;
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/StatusConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/StatusConfig.java
@@ -3,9 +3,7 @@ package cloud.benchflow.faban.client.configurations;
 import cloud.benchflow.faban.client.responses.RunId;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 28/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 28/10/15.
  */
 public class StatusConfig implements Config {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/SubmitConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/SubmitConfig.java
@@ -9,25 +9,25 @@ import java.io.InputStream;
  */
 public class SubmitConfig implements Config {
 
-    private String benchmarkName;
-    private String profile;
-    private InputStream configFile;
+  private String benchmarkName;
+  private String profile;
+  private InputStream configFile;
 
-    public SubmitConfig(String benchmarkName, String profile, InputStream configFile) {
-        this.benchmarkName = benchmarkName;
-        this.profile = profile;
-        this.configFile = configFile;
-    }
+  public SubmitConfig(String benchmarkName, String profile, InputStream configFile) {
+    this.benchmarkName = benchmarkName;
+    this.profile = profile;
+    this.configFile = configFile;
+  }
 
-    public String getBenchmarkName() {
-        return benchmarkName;
-    }
+  public String getBenchmarkName() {
+    return benchmarkName;
+  }
 
-    public String getProfile() {
-        return profile;
-    }
+  public String getProfile() {
+    return profile;
+  }
 
-    public InputStream getConfigFile() {
-        return configFile;
-    }
+  public InputStream getConfigFile() {
+    return configFile;
+  }
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/SubmitConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/SubmitConfig.java
@@ -11,6 +11,12 @@ public class SubmitConfig implements Config {
   private String profile;
   private InputStream configFile;
 
+  /**
+   * Construct a SubmitConfig.
+   * @param benchmarkName the benchmark name
+   * @param profile the benchmark profile
+   * @param configFile the configuration file for this run
+   */
   public SubmitConfig(String benchmarkName, String profile, InputStream configFile) {
     this.benchmarkName = benchmarkName;
     this.profile = profile;

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/SubmitConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/SubmitConfig.java
@@ -3,9 +3,7 @@ package cloud.benchflow.faban.client.configurations;
 import java.io.InputStream;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 28/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 28/10/15.
  */
 public class SubmitConfig implements Config {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/BenchmarkNameNotFoundException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/BenchmarkNameNotFoundException.java
@@ -5,12 +5,12 @@ package cloud.benchflow.faban.client.exceptions;
  *         <p/>
  *         Created on 29/10/15.
  */
-public class BenchmarkNameNotFoundException extends FabanClientException{
-    public BenchmarkNameNotFoundException(String message) {
-        super(message);
-    }
+public class BenchmarkNameNotFoundException extends FabanClientException {
+  public BenchmarkNameNotFoundException(String message) {
+    super(message);
+  }
 
-    public BenchmarkNameNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public BenchmarkNameNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/BenchmarkNameNotFoundException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/BenchmarkNameNotFoundException.java
@@ -1,7 +1,7 @@
 package cloud.benchflow.faban.client.exceptions;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
+ * @author Simone D'Avico (simonedavico@gmail.com)
  *         <p/>
  *         Created on 29/10/15.
  */

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/ConfigFileNotFoundException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/ConfigFileNotFoundException.java
@@ -6,7 +6,7 @@ package cloud.benchflow.faban.client.exceptions;
  * Created on 28/10/15.
  */
 public class ConfigFileNotFoundException extends Exception {
-    public ConfigFileNotFoundException(String message) {
-        super(message);
-    }
+  public ConfigFileNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/ConfigFileNotFoundException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/ConfigFileNotFoundException.java
@@ -1,9 +1,7 @@
 package cloud.benchflow.faban.client.exceptions;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 28/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 28/10/15.
  */
 public class ConfigFileNotFoundException extends Exception {
   public ConfigFileNotFoundException(String message) {

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/DeployException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/DeployException.java
@@ -7,12 +7,12 @@ package cloud.benchflow.faban.client.exceptions;
  */
 public class DeployException extends FabanClientException {
 
-    public DeployException(String message) {
-        super(message);
-    }
+  public DeployException(String message) {
+    super(message);
+  }
 
-    public DeployException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public DeployException(String message, Throwable cause) {
+    super(message, cause);
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/EmptyHarnessResponseException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/EmptyHarnessResponseException.java
@@ -9,7 +9,7 @@ public class EmptyHarnessResponseException extends FabanClientException {
 
   public EmptyHarnessResponseException() {
     super();
-  };
+  }
 
   public EmptyHarnessResponseException(String message) {
     super(message);

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/EmptyHarnessResponseException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/EmptyHarnessResponseException.java
@@ -1,7 +1,7 @@
 package cloud.benchflow.faban.client.exceptions;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
+ * @author Simone D'Avico (simonedavico@gmail.com)
  *         <p/>
  *         Created on 29/10/15.
  */

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/EmptyHarnessResponseException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/EmptyHarnessResponseException.java
@@ -7,15 +7,15 @@ package cloud.benchflow.faban.client.exceptions;
  */
 public class EmptyHarnessResponseException extends FabanClientException {
 
-    public EmptyHarnessResponseException() {
-        super();
-    };
+  public EmptyHarnessResponseException() {
+    super();
+  };
 
-    public EmptyHarnessResponseException(String message) {
-        super(message);
-    }
+  public EmptyHarnessResponseException(String message) {
+    super(message);
+  }
 
-    public EmptyHarnessResponseException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public EmptyHarnessResponseException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/FabanClientException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/FabanClientException.java
@@ -5,7 +5,7 @@ package cloud.benchflow.faban.client.exceptions;
  */
 public class FabanClientException extends RuntimeException {
 
-  public FabanClientException() {};
+  public FabanClientException() {}
 
   public FabanClientException(String message) {
     super(message);

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/FabanClientException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/FabanClientException.java
@@ -5,14 +5,14 @@ package cloud.benchflow.faban.client.exceptions;
  */
 public class FabanClientException extends RuntimeException {
 
-    public FabanClientException() {};
+  public FabanClientException() {};
 
-    public FabanClientException(String message) {
-        super(message);
-    }
+  public FabanClientException(String message) {
+    super(message);
+  }
 
-    public FabanClientException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public FabanClientException(String message, Throwable cause) {
+    super(message, cause);
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/IllegalRunIdException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/IllegalRunIdException.java
@@ -4,7 +4,7 @@ package cloud.benchflow.faban.client.exceptions;
  * Created by simonedavico on 28/10/15.
  */
 public class IllegalRunIdException extends FabanClientException {
-    public IllegalRunIdException(String s) {
-        super(s);
-    }
+  public IllegalRunIdException(String s) {
+    super(s);
+  }
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/IllegalRunStatusException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/IllegalRunStatusException.java
@@ -5,7 +5,7 @@ package cloud.benchflow.faban.client.exceptions;
  */
 public class IllegalRunStatusException extends FabanClientException {
 
-    public IllegalRunStatusException(String s) {
-        super(s);
-    }
+  public IllegalRunStatusException(String s) {
+    super(s);
+  }
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/JarFileNotFoundException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/JarFileNotFoundException.java
@@ -8,12 +8,12 @@ package cloud.benchflow.faban.client.exceptions;
  */
 public class JarFileNotFoundException extends Exception {
 
-    public JarFileNotFoundException(String message) {
-        super(message);
-    }
+  public JarFileNotFoundException(String message) {
+    super(message);
+  }
 
-    public JarFileNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public JarFileNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/JarFileNotFoundException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/JarFileNotFoundException.java
@@ -2,9 +2,7 @@ package cloud.benchflow.faban.client.exceptions;
 
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 28/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 28/10/15.
  */
 public class JarFileNotFoundException extends Exception {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/MalformedURIException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/MalformedURIException.java
@@ -5,11 +5,11 @@ package cloud.benchflow.faban.client.exceptions;
  */
 public class MalformedURIException extends FabanClientException {
 
-    public MalformedURIException(String message) {
-        super(message);
-    }
+  public MalformedURIException(String message) {
+    super(message);
+  }
 
-    public MalformedURIException(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public MalformedURIException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/NoConfigException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/NoConfigException.java
@@ -5,8 +5,8 @@ package cloud.benchflow.faban.client.exceptions;
  */
 public class NoConfigException extends FabanClientException {
 
-    public NoConfigException(String message) {
-        super(message);
-    }
+  public NoConfigException(String message) {
+    super(message);
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/RunIdNotFoundException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/RunIdNotFoundException.java
@@ -1,7 +1,7 @@
 package cloud.benchflow.faban.client.exceptions;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
+ * @author Simone D'Avico (simonedavico@gmail.com)
  *         <p/>
  *         Created on 29/10/15.
  */

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
@@ -1,6 +1,7 @@
 package cloud.benchflow.faban.client.responses;
 
 import cloud.benchflow.faban.client.exceptions.DeployException;
+
 import org.apache.http.HttpStatus;
 
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
@@ -17,7 +17,10 @@ public class DeployStatus implements Response {
 
   private Code code;
 
-
+  /**
+   * Construct a Deploy Status response.
+   * @param statusCode the deploy status code
+   */
   public DeployStatus(int statusCode) {
     switch (statusCode) {
       case HttpStatus.SC_CREATED:

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
@@ -20,13 +20,13 @@ public class DeployStatus implements Response {
 
   public DeployStatus(int statusCode) {
     switch (statusCode) {
-      case (HttpStatus.SC_CREATED):
+      case HttpStatus.SC_CREATED:
         this.code = Code.CREATED;
         break;
-      case (HttpStatus.SC_CONFLICT):
+      case HttpStatus.SC_CONFLICT:
         this.code = Code.CONFLICT;
         break;
-      case (HttpStatus.SC_NOT_ACCEPTABLE):
+      case HttpStatus.SC_NOT_ACCEPTABLE:
         this.code = Code.NOT_ACCEPTABLE;
         break;
       default:

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
@@ -10,32 +10,32 @@ import org.apache.http.HttpStatus;
  */
 public class DeployStatus implements Response {
 
-    public enum Code {
-        CONFLICT, NOT_ACCEPTABLE, CREATED
+  public enum Code {
+    CONFLICT, NOT_ACCEPTABLE, CREATED
+  }
+
+  private Code code;
+
+
+  public DeployStatus(int statusCode) {
+    switch (statusCode) {
+      case (HttpStatus.SC_CREATED):
+        this.code = Code.CREATED;
+        break;
+      case (HttpStatus.SC_CONFLICT):
+        this.code = Code.CONFLICT;
+        break;
+      case (HttpStatus.SC_NOT_ACCEPTABLE):
+        this.code = Code.NOT_ACCEPTABLE;
+        break;
+      default:
+        throw new DeployException(
+            "Deploy returned response with unexpected " + "status code " + statusCode);
     }
+  }
 
-    private Code code;
-
-
-    public DeployStatus(int statusCode) {
-        switch(statusCode) {
-            case(HttpStatus.SC_CREATED):
-                this.code = Code.CREATED;
-                break;
-            case(HttpStatus.SC_CONFLICT):
-                this.code = Code.CONFLICT;
-                break;
-            case(HttpStatus.SC_NOT_ACCEPTABLE):
-                this.code = Code.NOT_ACCEPTABLE;
-                break;
-            default:
-                throw new DeployException("Deploy returned response with unexpected " +
-                                          "status code " + statusCode);
-        }
-    }
-
-    public Code getCode() {
-        return this.code;
-    }
+  public Code getCode() {
+    return this.code;
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
@@ -7,7 +7,7 @@ import org.apache.http.HttpStatus;
 
 /**
  *
- * @author Simone D'Avico <simonedavico@gmail.com>
+ * @author Simone D'Avico (simonedavico@gmail.com)
  */
 public class DeployStatus implements Response {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/Response.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/Response.java
@@ -5,7 +5,7 @@ import java.util.function.Function;
 
 /**
  *
- * @author Simone D'Avico <simonedavico@gmail.com>
+ * @author Simone D'Avico (simonedavico@gmail.com)
  */
 @SuppressWarnings("unchecked")
 public interface Response {

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/Response.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/Response.java
@@ -10,12 +10,12 @@ import java.util.function.Function;
 @SuppressWarnings("unchecked")
 public interface Response {
 
-    default <R extends Response, T> T handle(Function<R, T> handler) {
-        return handler.apply((R)this);
-    }
+  default <R extends Response, T> T handle(Function<R, T> handler) {
+    return handler.apply((R) this);
+  }
 
-    default <R extends Response> void handle(Consumer<R> consumer) {
-        consumer.accept((R)this);
-    }
+  default <R extends Response> void handle(Consumer<R> consumer) {
+    consumer.accept((R) this);
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunId.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunId.java
@@ -18,8 +18,9 @@ public class RunId implements Response {
 
   public RunId(String runId) {
     String[] parts = runId.split("\\.");
-    if (parts.length != 2)
+    if (parts.length != 2) {
       throw new IllegalRunIdException("Received unexpected runId " + runId);
+    }
     this.name = parts[0];
     this.queueId = parts[1];
   }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunId.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunId.java
@@ -4,7 +4,7 @@ import cloud.benchflow.faban.client.exceptions.IllegalRunIdException;
 
 /**
  *
- * @author Simone D'Avico <simonedavico@gmail.com>
+ * @author Simone D'Avico (simonedavico@gmail.com)
  */
 public class RunId implements Response {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunId.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunId.java
@@ -11,11 +11,20 @@ public class RunId implements Response {
   private String name;
   private String queueId;
 
+  /**
+   * Contruct a run id response.
+   * @param name the name of the benchmark
+   * @param queueId the id of the benchmark in the queue
+   */
   public RunId(String name, String queueId) {
     this.name = name;
     this.queueId = queueId;
   }
 
+  /**
+   * Contruct a run id response.
+   * @param runId the run id of the benchmark
+   */
   public RunId(String runId) {
     String[] parts = runId.split("\\.");
     if (parts.length != 2) {

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunId.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunId.java
@@ -8,25 +8,25 @@ import cloud.benchflow.faban.client.exceptions.IllegalRunIdException;
  */
 public class RunId implements Response {
 
-    private String name;
-    private String queueId;
+  private String name;
+  private String queueId;
 
-    public RunId(String name, String queueId) {
-        this.name = name;
-        this.queueId = queueId;
-    }
+  public RunId(String name, String queueId) {
+    this.name = name;
+    this.queueId = queueId;
+  }
 
-    public RunId(String runId) {
-        String[] parts = runId.split("\\.");
-        if(parts.length != 2)
-            throw new IllegalRunIdException("Received unexpected runId " + runId);
-        this.name = parts[0];
-        this.queueId = parts[1];
-    }
+  public RunId(String runId) {
+    String[] parts = runId.split("\\.");
+    if (parts.length != 2)
+      throw new IllegalRunIdException("Received unexpected runId " + runId);
+    this.name = parts[0];
+    this.queueId = parts[1];
+  }
 
-    @Override
-    public String toString() {
-        return this.name + "." + this.queueId;
-    }
+  @Override
+  public String toString() {
+    return this.name + "." + this.queueId;
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunLog.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunLog.java
@@ -1,9 +1,7 @@
 package cloud.benchflow.faban.client.responses;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 11/11/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 11/11/15.
  */
 public class RunLog {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunLog.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunLog.java
@@ -7,14 +7,14 @@ package cloud.benchflow.faban.client.responses;
  */
 public class RunLog {
 
-    private String content;
+  private String content;
 
-    public RunLog(String content) {
-        this.content = content;
-    }
+  public RunLog(String content) {
+    this.content = content;
+  }
 
-    public String getContent() {
-        return content;
-    }
+  public String getContent() {
+    return content;
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunLogStream.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunLogStream.java
@@ -4,9 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 11/11/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 11/11/15.
  */
 public class RunLogStream implements AutoCloseable, Response {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunLogStream.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunLogStream.java
@@ -10,21 +10,21 @@ import java.io.IOException;
  */
 public class RunLogStream implements AutoCloseable, Response {
 
-    private BufferedReader reader;
+  private BufferedReader reader;
 
-    public RunLogStream(BufferedReader reader) {
-        this.reader = reader;
-    }
+  public RunLogStream(BufferedReader reader) {
+    this.reader = reader;
+  }
 
-    public RunLog readLog() throws IOException {
-        String r = reader.readLine();
-        return r == null ? null : new RunLog(r);
-    }
+  public RunLog readLog() throws IOException {
+    String r = reader.readLine();
+    return r == null ? null : new RunLog(r);
+  }
 
 
-    @Override
-    public void close() throws Exception {
-        this.reader.close();
-    }
+  @Override
+  public void close() throws Exception {
+    this.reader.close();
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunQueue.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunQueue.java
@@ -7,9 +7,7 @@ import java.util.Spliterator;
 import java.util.function.Consumer;
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 30/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 30/10/15.
  */
 public class RunQueue implements Response, Iterable<RunId> {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunQueue.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunQueue.java
@@ -13,33 +13,33 @@ import java.util.function.Consumer;
  */
 public class RunQueue implements Response, Iterable<RunId> {
 
-    private List<RunId> queue;
+  private List<RunId> queue;
 
-    public RunQueue() {
-        queue = new ArrayList<>();
-    }
+  public RunQueue() {
+    queue = new ArrayList<>();
+  }
 
-    public void add(RunId runId) {
-        queue.add(runId);
-    }
+  public void add(RunId runId) {
+    queue.add(runId);
+  }
 
-    @Override
-    public Iterator<RunId> iterator() {
-        return queue.iterator();
-    }
+  @Override
+  public Iterator<RunId> iterator() {
+    return queue.iterator();
+  }
 
-    @Override
-    public void forEach(Consumer<? super RunId> action) {
-        queue.forEach(action);
-    }
+  @Override
+  public void forEach(Consumer<? super RunId> action) {
+    queue.forEach(action);
+  }
 
-    @Override
-    public Spliterator<RunId> spliterator() {
-        return queue.spliterator();
-    }
+  @Override
+  public Spliterator<RunId> spliterator() {
+    return queue.spliterator();
+  }
 
-    public boolean contains(RunId id) {
-        return queue.contains(id);
-    }
+  public boolean contains(RunId id) {
+    return queue.contains(id);
+  }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
@@ -3,9 +3,7 @@ package cloud.benchflow.faban.client.responses;
 import cloud.benchflow.faban.client.exceptions.IllegalRunStatusException;
 
 /**
- * @author Simone D'Avico (simonedavico@gmail.com)
- *
- * Created on 28/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 28/10/15.
  */
 public class RunStatus implements Response {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
@@ -9,10 +9,18 @@ public class RunStatus implements Response {
 
   private Code status;
 
+  /**
+   * Possible run statuses.
+   */
   public enum Code {
     QUEUED, RECEIVED, STARTED, COMPLETED, FAILED, KILLED, KILLING, DENIED
   }
 
+  /**
+   * Construct a run status.
+   * @param statusCode the status code
+   * @param runId the run id
+   */
   public RunStatus(String statusCode, RunId runId) {
     switch (statusCode.replace("\n", "")) {
       case "QUEUED":

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
@@ -9,46 +9,47 @@ import cloud.benchflow.faban.client.exceptions.IllegalRunStatusException;
  */
 public class RunStatus implements Response {
 
-    private Code status;
+  private Code status;
 
-    public enum Code { QUEUED, RECEIVED, STARTED, COMPLETED, FAILED, KILLED, KILLING, DENIED };
+  public enum Code {
+    QUEUED, RECEIVED, STARTED, COMPLETED, FAILED, KILLED, KILLING, DENIED
+  };
 
-    public RunStatus(String statusCode, RunId runId) {
-        switch (statusCode.replace("\n", "")) {
-            case "QUEUED":
-                this.status = Code.QUEUED;
-                break;
-            case "RECEIVED":
-                this.status = Code.RECEIVED;
-                break;
-            case "STARTED":
-                this.status = Code.STARTED;
-                break;
-            case "COMPLETED":
-                this.status = Code.COMPLETED;
-                break;
-            case "FAILED":
-                this.status = Code.FAILED;
-                break;
-            case "KILLED":
-                this.status = Code.KILLED;
-                break;
-            case "KILLING":
-                this.status = Code.KILLING;
-                break;
-            case "DENIED":
-                this.status = Code.DENIED;
-                break;
-            default:
-                throw new IllegalRunStatusException("RunId " + runId +
-                                                    "returned illegal run status " +
-                                                    statusCode);
-        }
+  public RunStatus(String statusCode, RunId runId) {
+    switch (statusCode.replace("\n", "")) {
+      case "QUEUED":
+        this.status = Code.QUEUED;
+        break;
+      case "RECEIVED":
+        this.status = Code.RECEIVED;
+        break;
+      case "STARTED":
+        this.status = Code.STARTED;
+        break;
+      case "COMPLETED":
+        this.status = Code.COMPLETED;
+        break;
+      case "FAILED":
+        this.status = Code.FAILED;
+        break;
+      case "KILLED":
+        this.status = Code.KILLED;
+        break;
+      case "KILLING":
+        this.status = Code.KILLING;
+        break;
+      case "DENIED":
+        this.status = Code.DENIED;
+        break;
+      default:
+        throw new IllegalRunStatusException(
+            "RunId " + runId + "returned illegal run status " + statusCode);
     }
+  }
 
-    public Code getStatus() {
-        return this.status;
-    }
+  public Code getStatus() {
+    return this.status;
+  }
 
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
@@ -13,7 +13,7 @@ public class RunStatus implements Response {
 
   public enum Code {
     QUEUED, RECEIVED, STARTED, COMPLETED, FAILED, KILLED, KILLING, DENIED
-  };
+  }
 
   public RunStatus(String statusCode, RunId runId) {
     switch (statusCode.replace("\n", "")) {

--- a/benchflow-faban-client/src/test/java/cloud/benchflow/faban/test/client/Main.java
+++ b/benchflow-faban-client/src/test/java/cloud/benchflow/faban/test/client/Main.java
@@ -7,7 +7,6 @@ import cloud.benchflow.faban.client.exceptions.ConfigFileNotFoundException;
 import cloud.benchflow.faban.client.exceptions.JarFileNotFoundException;
 import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
 import cloud.benchflow.faban.client.responses.DeployStatus;
-import cloud.benchflow.faban.client.responses.RunId;
 
 import java.io.IOException;
 import java.net.URI;

--- a/benchflow-faban-client/src/test/java/cloud/benchflow/faban/test/client/Main.java
+++ b/benchflow-faban-client/src/test/java/cloud/benchflow/faban/test/client/Main.java
@@ -23,22 +23,23 @@ import java.nio.file.Paths;
  */
 public class Main {
 
-    public static void main(String[] args) throws IOException, URISyntaxException, RunIdNotFoundException {
+  public static void main(String[] args)
+      throws IOException, URISyntaxException, RunIdNotFoundException {
 
-        //get an instance of faban client
-        FabanClientConfig fcprova = new FabanClientConfigImpl("deployer","adminadmin",new URI(""));
+    //get an instance of faban client
+    FabanClientConfig fcprova = new FabanClientConfigImpl("deployer", "adminadmin", new URI(""));
 
-        FabanClient client = new FabanClient().withConfig(fcprova);
-        Path bm = Paths.get("./src/test/resources/foofoofoo.jar");
-        Path configFile = Paths.get("./src/test/resources/");
+    FabanClient client = new FabanClient().withConfig(fcprova);
+    Path bm = Paths.get("./src/test/resources/foofoofoo.jar");
+    Path configFile = Paths.get("./src/test/resources/");
 
-        try {
-            client.deploy(bm.toFile()).handle((DeployStatus s) -> System.out.println(s.getCode()));
-            client.submit("fooBenchmark", "fooBenchmark", Paths.get("").toFile());
-        } catch (JarFileNotFoundException | ConfigFileNotFoundException e) {
-            e.printStackTrace();
-        }
-
+    try {
+      client.deploy(bm.toFile()).handle((DeployStatus s) -> System.out.println(s.getCode()));
+      client.submit("fooBenchmark", "fooBenchmark", Paths.get("").toFile());
+    } catch (JarFileNotFoundException | ConfigFileNotFoundException e) {
+      e.printStackTrace();
     }
+
+  }
 
 }

--- a/benchflow-faban-client/src/test/java/cloud/benchflow/faban/test/client/Main.java
+++ b/benchflow-faban-client/src/test/java/cloud/benchflow/faban/test/client/Main.java
@@ -16,9 +16,7 @@ import java.nio.file.Paths;
 
 
 /**
- * @author Simone D'Avico <simonedavico@gmail.com>
- *
- * Created on 26/10/15.
+ * @author Simone D'Avico (simonedavico@gmail.com) - Created on 26/10/15.
  */
 public class Main {
 

--- a/docs/developer-guide/coding-practices.md
+++ b/docs/developer-guide/coding-practices.md
@@ -125,7 +125,17 @@ To help format your code according to the guidelines you probably want to use a 
       which runs before the compiler
 
 ### Java
-We are following the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
+
+We are following the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html) with the following adaptations:
+
+- names may contain up to 5 consecutive capital letters
+
+
+The requirements of this style guide are quite reasonable. In particular with regards to Javadoc checks:
+
+- only public methods have to be documented
+- it is not mandatory to document each single parameter, thrown exception, or return. This is good because in practice sometimes only a textual description is enough. The traditional checks force you to document each single parameter which leads to useless documentation like "experimentID: the ID of the experiment". But it is important to notice that if you do write an "@param someParameter" or a "@throws SomeException" without documentation the static check will complain
+- methods with less than 3 lines (we can change this parameter if you want) don't have to be documented. That is also great because if you're forced to document obvious code like getters and setters then nobody takes the static checks seriously.
 
 #### Checker
 
@@ -153,24 +163,19 @@ To check it we are using [checkstyle](http://checkstyle.sourceforge.net/).
 
 - Maven
   
-  The maven plug-in responsible for formatting (<https://github.com/coveo/fmt-maven-plugin>) basically calls the software Google users to format their Java code (<https://github.com/google/google-java-format>)
-which they say doesn't accept configuration on purpose to make sure nobody deviates from the standard.
+  To automatically format the code following the standard we use [formatter-maven-plugin](http://code.revelc.net/formatter-maven-plugin/formatter-maven-plugin/index.html) which uses the Eclipse code formatter. It formats the code using rules provided by a Eclipse formatter configuration file. The file is available in the repository.
 
-  If we decide we want to have a standard that is based on the Google standard but with something different we have to use a formatter that accepts configuration. For example:
-[formatter-maven-plugin](http://code.revelc.net/formatter-maven-plugin/formatter-maven-plugin/index.html)
-
-  Run it with
+  You can run it manually with
 
   ```
-  mvn com.coveo:fmt-maven-plugin:format
+  mvn java-formatter:format
   ```
 
   or it will run automatically before the compiler
 
 - Eclipse
   
-  You can configure the built-in formatter with this configuration file:
-  <https://github.com/google/styleguide/blob/gh-pages/eclipse-java-google-style.xml>
+  You can configure the built-in formatter with the same configuration file used by the Maven plug-in.
 
 - IntelliJ
  


### PR DESCRIPTION
The remaining issues in the faban client are all caused by lack of proper Javadoc documentation. I think it's probably more productive for someone that already has knowledge of the code base to document these methods.

I want to add that unlike traditional Javadoc checks, the current checks are very reasonable so it's worth to follow them. Here's part of the set up right now (which we can also find to if we decide to):
```
        <module name="JavadocMethod">
            <property name="scope" value="public"/>
            <property name="allowMissingParamTags" value="true"/>
            <property name="allowMissingThrowsTags" value="true"/>
            <property name="allowMissingReturnTag" value="true"/>
            <property name="minLineCount" value="2"/>
            ...
        </module>
```

This means that:
- only public methods have to be documented
- it is not mandatory to document each single parameter, thrown exception, or return. This is good because in practice sometimes only a textual description is enough. The traditional checks force you to document each single parameter which leads to useless documentation like "experimentID: the ID of the experiment". But it is important to notice that if you do write an "@param someParameter" or a "@throws SomeException" without documentation the static check will complain
- methods with less than 3 lines (we can change this parameter if you want) don't have to be documented. That is also great because if you're forced to document obvious code like getters and setters then nobody takes the static checks seriously