### PR TITLE
DSL docker-compose generation

### DIFF
--- a/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/BenchFlowDSL.scala
+++ b/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/BenchFlowDSL.scala
@@ -4,6 +4,7 @@ import cloud.benchflow.dsl.definition.BenchFlowExperimentYamlProtocol._
 import cloud.benchflow.dsl.definition.BenchFlowTestYamlProtocol._
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException
 import cloud.benchflow.dsl.definition.{ BenchFlowExperiment, BenchFlowExperimentYamlBuilder, BenchFlowTest }
+import cloud.benchflow.dsl.dockercompose.DockerComposeYamlBuilder
 import net.jcazevedo.moultingyaml._
 
 import scala.util.{ Failure, Success, Try }
@@ -141,6 +142,20 @@ object BenchFlowDSL {
     val experiment = experimentFromTestYaml(testDefinitionYaml)
 
     new BenchFlowExperimentYamlBuilder(experiment)
+
+  }
+
+  /**
+   * Returns a DockerComposeYamlBuilder for creating a custom docker-compose yaml
+   *
+   * @param dockerComposeYamlString docker-compose.yml
+   * @return
+   */
+  def dockerComposeYamlBuilderFromDockerComposeYaml(dockerComposeYamlString: String): DockerComposeYamlBuilder = {
+
+    val dockerComposeYaml = dockerComposeYamlString.parseYaml
+
+    new DockerComposeYamlBuilder(dockerComposeYaml)
 
   }
 

--- a/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/dockercompose/DockerComposeYamlBuilder.scala
+++ b/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/dockercompose/DockerComposeYamlBuilder.scala
@@ -1,0 +1,67 @@
+package cloud.benchflow.dsl.dockercompose
+
+import cloud.benchflow.dsl.definition.types.bytes.Bytes
+import cloud.benchflow.dsl.definition.types.bytes.BytesYamlProtocol._
+import net.jcazevedo.moultingyaml.{ YamlString, YamlValue, _ }
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com)
+ *         created on 2017-05-25
+ */
+class DockerComposeYamlBuilder(dockerComposeYamlValue: YamlValue) {
+
+  val ServicesKey = YamlString("services")
+  val MemLimitKey = YamlString("mem_limit")
+  val EnvironmentKey = YamlString("environment")
+
+  def memLimit(serviceName: String, memLimit: Bytes): DockerComposeYamlBuilder = {
+
+    val serviceKey = serviceName.toYaml
+
+    val servicesYamlObject = dockerComposeYamlValue.asYamlObject.fields(ServicesKey).asYamlObject
+
+    val serviceYamlObject = servicesYamlObject.fields(serviceKey).asYamlObject
+
+    // add/change the memory limit
+    val serviceConfigurationYamlObject = YamlObject(serviceYamlObject.fields + (MemLimitKey -> memLimit.toYaml))
+
+    // construct new docker compose
+    val newYamlObject = YamlObject(dockerComposeYamlValue.asYamlObject.fields +
+      (ServicesKey -> YamlObject(servicesYamlObject.fields
+        + (serviceKey -> serviceConfigurationYamlObject))))
+
+    new DockerComposeYamlBuilder(newYamlObject)
+
+  }
+
+  //  def cpus()
+
+  def environmentVariable(serviceName: String, variableName: String, variableValue: String): DockerComposeYamlBuilder = {
+
+    val serviceKey = serviceName.toYaml
+
+    val servicesYamlObject = dockerComposeYamlValue.asYamlObject.fields(ServicesKey).asYamlObject
+
+    val serviceYamlObject = servicesYamlObject.fields(serviceKey).asYamlObject
+
+    val environmentList = serviceYamlObject.fields(EnvironmentKey).asInstanceOf[YamlArray].elements.toList
+
+    // add/change the environment
+    val newEnvironmentList = YamlString(s"$variableName=$variableValue") ::
+      environmentList.filterNot(value => value.convertTo[String].contains(s"$variableName="))
+
+    // construct new docker compose
+    val newYamlObject = YamlObject(dockerComposeYamlValue.asYamlObject.fields +
+      (ServicesKey -> YamlObject(servicesYamlObject.fields
+        + (serviceKey -> YamlObject(serviceYamlObject.fields
+          + (EnvironmentKey -> newEnvironmentList.toYaml))))))
+
+    new DockerComposeYamlBuilder(newYamlObject)
+
+  }
+
+  def build(): String = {
+    dockerComposeYamlValue.prettyPrint
+  }
+
+}

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/BenchFlowDSLTest.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/BenchFlowDSLTest.scala
@@ -3,8 +3,10 @@ package cloud.benchflow.dsl
 import java.nio.file.Paths
 
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException
+import cloud.benchflow.dsl.definition.types.bytes.{ Bytes, BytesUnit }
 import org.junit.{ Assert, Test }
 import org.scalatest.junit.JUnitSuite
+import cloud.benchflow.dsl.dockercompose.DockerComposeYamlString
 
 import scala.io.Source
 
@@ -78,6 +80,26 @@ class BenchFlowDSLTest extends JUnitSuite {
       Assert.assertTrue(experimentYaml.contains("users: " + numUsers))
 
     })
+
+  }
+
+  @Test def dockerComposeBuilderTest(): Unit = {
+
+    val dockerComposeString = DockerComposeYamlString
+
+    val serviceName = "camunda"
+    val underlying = 500
+    val memLimit: Bytes = new Bytes(underlying = underlying, unit = BytesUnit.MegaBytes)
+    val environmentKey = "DB_DRIVER"
+    val environmentValue = "TEST_ENVIRONMENT_VALUE"
+
+    val generatedComposeString = BenchFlowDSL.dockerComposeYamlBuilderFromDockerComposeYaml(dockerComposeString)
+      .environmentVariable(serviceName, environmentKey, environmentValue)
+      .memLimit(serviceName, memLimit).build()
+
+    Assert.assertTrue(generatedComposeString.contains(s"mem_limit: ${memLimit.underlying}${memLimit.unit}"))
+    Assert.assertTrue(generatedComposeString.contains(s"$environmentKey=$environmentValue"))
+    Assert.assertFalse(generatedComposeString.contains(s"DB_DRIVER=com.mysql.jdbc.Driver"))
 
   }
 

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/dockercompose/DockerComposeYamlBuilderTest.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/dockercompose/DockerComposeYamlBuilderTest.scala
@@ -1,0 +1,36 @@
+package cloud.benchflow.dsl.dockercompose
+
+import cloud.benchflow.dsl.definition.types.bytes.{ Bytes, BytesUnit }
+import net.jcazevedo.moultingyaml._
+import org.junit.{ Assert, Test }
+import org.scalatest.junit.JUnitSuite
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com)
+ *         created on 2017-05-25
+ */
+class DockerComposeYamlBuilderTest extends JUnitSuite {
+
+  @Test
+  def changeMemoryAndEnvironmentVariables(): Unit = {
+
+    val dockerComposeYaml = DockerComposeYamlString.parseYaml
+
+    val serviceName = "camunda"
+    val underlying = 500
+    val memLimit: Bytes = new Bytes(underlying = underlying, unit = BytesUnit.MegaBytes)
+    val environmentKey = "DB_DRIVER"
+    val environmentValue = "TEST_ENVIRONMENT_VALUE"
+
+    val newDockerComposeYamlString = new DockerComposeYamlBuilder(dockerComposeYaml)
+      .memLimit(serviceName, memLimit)
+      .environmentVariable(serviceName, environmentKey, environmentValue)
+      .build()
+
+    Assert.assertTrue(newDockerComposeYamlString.contains(s"mem_limit: ${memLimit.underlying}${memLimit.unit}"))
+    Assert.assertTrue(newDockerComposeYamlString.contains(s"$environmentKey=$environmentValue"))
+    Assert.assertFalse(newDockerComposeYamlString.contains(s"DB_DRIVER=com.mysql.jdbc.Driver"))
+
+  }
+
+}

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/dockercompose/package.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/dockercompose/package.scala
@@ -1,0 +1,39 @@
+package cloud.benchflow.dsl
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com)
+ *         created on 2017-05-25
+ */
+package object dockercompose {
+
+  // TODO - validate with VF it this is a good example
+  val DockerComposeYamlString: String =
+    """
+      |version: '2'
+      |services:
+      |  camunda:
+      |    image: 'camunda/camunda-bpm-platform:tomcat-7.5.0'
+      |    command: bash -c "sleep 20 && /usr/local/bin/configure-and-run.sh"
+      |    environment:
+      |      - DB_DRIVER=com.mysql.jdbc.Driver
+      |      - DB_PASSWORD=${BENCHFLOW_db_MYSQL_PASSWORD}
+      |      - DB_URL=jdbc:mysql://${BENCHFLOW_db_IP}:${BENCHFLOW_db_PORT}/${BENCHFLOW_db_MYSQL_DATABASE}
+      |      - DB_USERNAME=${BENCHFLOW_db_MYSQL_USER}
+      |      - JAVA_OPTS=-Djava.security.egd=file:/dev/./urandom
+      |    network_mode: host
+      |    ports:
+      |      - 8080:8080
+      |
+      |  db:
+      |    image: 'mysql:latest'
+      |    environment:
+      |      - MYSQL_DATABASE=process-engine
+      |      - MYSQL_PASSWORD=camunda
+      |      - MYSQL_ROOT_PASSWORD=camunda
+      |      - MYSQL_USER=camunda
+      |    network_mode: host
+      |    ports:
+      |      - 3306:3306
+    """.stripMargin
+
+}


### PR DESCRIPTION
Adds support for generating docker-compose with memory limit and environment variables. 

In reference to https://github.com/benchflow/benchflow/issues/341