### PR TITLE
Adds Generation of Initial Exploration Space

### DIFF
--- a/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/BenchFlowDSL.scala
+++ b/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/BenchFlowDSL.scala
@@ -5,6 +5,8 @@ import cloud.benchflow.dsl.definition.BenchFlowTestYamlProtocol._
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException
 import cloud.benchflow.dsl.definition.{ BenchFlowExperiment, BenchFlowExperimentYamlBuilder, BenchFlowTest }
 import cloud.benchflow.dsl.dockercompose.DockerComposeYamlBuilder
+import cloud.benchflow.dsl.explorationspace.ExplorationSpaceGenerator
+import cloud.benchflow.dsl.explorationspace.ExplorationSpaceGenerator.{ ExplorationSpace, ExplorationSpaceState }
 import net.jcazevedo.moultingyaml._
 
 import scala.util.{ Failure, Success, Try }
@@ -156,6 +158,32 @@ object BenchFlowDSL {
     val dockerComposeYaml = dockerComposeYamlString.parseYaml
 
     new DockerComposeYamlBuilder(dockerComposeYaml)
+
+  }
+
+  /**
+   *
+   * @param testDefinitionYaml benchflow-test.yml
+   * @throws cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException
+   * @return ExplorationSpace
+   */
+  @throws(classOf[BenchFlowDeserializationException])
+  def explorationSpaceFromTestYaml(testDefinitionYaml: String): ExplorationSpace = {
+
+    val test = testFromYaml(testDefinitionYaml)
+
+    ExplorationSpaceGenerator.generateExplorationSpace(test)
+
+  }
+
+  /**
+   *
+   * @param explorationSpace
+   * @return initial state of exploration space
+   */
+  def getInitialExplorationSpaceState(explorationSpace: ExplorationSpace): ExplorationSpaceState = {
+
+    ExplorationSpaceGenerator.generateExplorationSpaceState(explorationSpace)
 
   }
 

--- a/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/BenchFlowDSL.scala
+++ b/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/BenchFlowDSL.scala
@@ -183,7 +183,7 @@ object BenchFlowDSL {
    */
   def getInitialExplorationSpaceState(explorationSpace: ExplorationSpace): ExplorationSpaceState = {
 
-    ExplorationSpaceGenerator.generateExplorationSpaceState(explorationSpace)
+    ExplorationSpaceGenerator.generateInitialExplorationSpaceState(explorationSpace)
 
   }
 

--- a/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/explorationspace/ExplorationSpaceGenerator.scala
+++ b/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/explorationspace/ExplorationSpaceGenerator.scala
@@ -1,0 +1,82 @@
+package cloud.benchflow.dsl.explorationspace
+
+import cloud.benchflow.dsl.definition.BenchFlowTest
+import cloud.benchflow.dsl.definition.types.bytes.Bytes
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com)
+ *         created on 2017-05-25
+ */
+object ExplorationSpaceGenerator {
+
+  type ServiceName = String
+  type VariableName = String
+  type VariableValue = String
+  type NumUsers = Int
+  type DimensionLength = Int
+
+  case class ExplorationSpaceState(
+    usersState: Option[(Int, DimensionLength)],
+    memoryState: Option[Map[ServiceName, (Int, DimensionLength)]],
+    environmentState: Option[Map[ServiceName, Map[VariableName, (Int, DimensionLength)]]])
+
+  case class ExplorationSpace(
+    users: Option[List[NumUsers]],
+    memory: Option[Map[ServiceName, List[Bytes]]],
+    environment: Option[Map[ServiceName, Map[VariableName, List[VariableValue]]]])
+
+  def generateExplorationSpace(test: BenchFlowTest): ExplorationSpace = {
+
+    val users: Option[List[NumUsers]] = test.configuration.goal.explorationSpace.flatMap(
+      _.workload.flatMap(
+        _.users.map(
+          _.values)))
+
+    val memory: Option[Map[ServiceName, List[Bytes]]] = for {
+
+      explorationSpace <- test.configuration.goal.explorationSpace
+
+      services <- explorationSpace.services
+
+      serviceMemorySpace = services.mapValues(
+        _.resources.flatMap(
+          _.memory.map(
+            _.values))).collect {
+          case (service, Some(memLimit)) => (service, memLimit)
+        }
+
+    } yield serviceMemorySpace
+
+    val environment: Option[Map[ServiceName, Map[VariableName, List[VariableValue]]]] = for {
+
+      explorationSpace <- test.configuration.goal.explorationSpace
+
+      services <- explorationSpace.services
+
+      environmentVariables = services.mapValues(
+        _.environment).collect {
+          case (service, Some(variableMap)) => (service, variableMap)
+        }
+
+    } yield environmentVariables
+
+    ExplorationSpace(users, memory, environment)
+
+  }
+
+  def generateExplorationSpaceState(explorationSpace: ExplorationSpace): ExplorationSpaceState = {
+
+    val usersState = explorationSpace.users.map(list => (0, list.length))
+
+    val memoryState = explorationSpace.memory.map(memory => memory.mapValues(list => (0, list.length)))
+
+    val environmentState = explorationSpace.environment.map(
+      environmentMap => environmentMap.mapValues(
+        environment => environment.mapValues(
+          list => (0, list.length))))
+
+    ExplorationSpaceState(usersState, memoryState, environmentState)
+
+  }
+
+}

--- a/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/explorationspace/ExplorationSpaceGenerator.scala
+++ b/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/explorationspace/ExplorationSpaceGenerator.scala
@@ -107,11 +107,15 @@ object ExplorationSpaceGenerator {
       usersDimensionLength <- explorationSpace.users.map(_.length)
 
       memoryDimensionLength <- explorationSpace.memory
-        .map(memory => memory.map(_._2.length).product)
+        .map(memory => memory.map {
+          case (_, values) => values.length
+        }.product)
 
       environmentDimensionLength <- explorationSpace.environment
         .map(environmentMap => environmentMap.map {
-          case (_, values) => values.map(_._2.length).product
+          case (_, variablesMap) => variablesMap.map {
+            case (_, values) => values.length
+          }.product
         }).map(_.product)
 
     } yield usersDimensionLength * memoryDimensionLength * environmentDimensionLength

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/BenchFlowDSLTest.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/BenchFlowDSLTest.scala
@@ -103,4 +103,36 @@ class BenchFlowDSLTest extends JUnitSuite {
 
   }
 
+  @Test def generateExplorationSpaceTest(): Unit = {
+
+    val testYaml = Source.fromFile(Paths.get(BenchFlowExplorationMultipleExample).toFile).mkString
+
+    val explorationSpace = BenchFlowDSL.explorationSpaceFromTestYaml(testYaml)
+
+    Assert.assertTrue(explorationSpace.users.isDefined)
+
+    Assert.assertTrue(explorationSpace.memory.isDefined)
+
+    Assert.assertTrue(explorationSpace.environment.isDefined)
+
+  }
+
+  @Test def initialExplorationSpaceStateTest(): Unit = {
+
+    val testYaml = Source.fromFile(Paths.get(BenchFlowExplorationMultipleExample).toFile).mkString
+
+    val explorationSpace = BenchFlowDSL.explorationSpaceFromTestYaml(testYaml)
+
+    val initialExplorationSpaceState = BenchFlowDSL.getInitialExplorationSpaceState(explorationSpace)
+
+    val expectedUsersState = (0, explorationSpace.users.get.length)
+    val expectedMemoryState = Map(("camunda", (0, 5)))
+    val expectedEnvironmentState = Map(("camunda", Map(("SIZE_OF_THREADPOOL", (0, 4)))))
+
+    Assert.assertEquals(expectedUsersState, initialExplorationSpaceState.usersState.get)
+    Assert.assertEquals(expectedMemoryState, initialExplorationSpaceState.memoryState.get)
+    Assert.assertEquals(expectedEnvironmentState, initialExplorationSpaceState.environmentState.get)
+
+  }
+
 }

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/BenchFlowDSLTest.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/BenchFlowDSLTest.scala
@@ -125,9 +125,16 @@ class BenchFlowDSLTest extends JUnitSuite {
 
     val initialExplorationSpaceState = BenchFlowDSL.getInitialExplorationSpaceState(explorationSpace)
 
-    val expectedUsersState = (0, explorationSpace.users.get.length)
-    val expectedMemoryState = Map(("camunda", (0, 5)))
-    val expectedEnvironmentState = Map(("camunda", Map(("SIZE_OF_THREADPOOL", (0, 4)))))
+    val expectedExplorationSpaceSize = 5 * 4 * 3 * 4
+
+    val expectedList = List.fill(expectedExplorationSpaceSize)(-1)
+
+    val expectedUsersState = (expectedList, explorationSpace.users.get.length)
+    val expectedMemoryState = Map(("camunda", (expectedList, 5)))
+    val expectedEnvironmentState = Map(
+      ("camunda", Map(
+        ("SIZE_OF_THREADPOOL", (expectedList, 4)),
+        ("AN_ENUM", (expectedList, 3)))))
 
     Assert.assertEquals(expectedUsersState, initialExplorationSpaceState.usersState.get)
     Assert.assertEquals(expectedMemoryState, initialExplorationSpaceState.memoryState.get)

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/BenchFlowDSLTest.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/BenchFlowDSLTest.scala
@@ -129,7 +129,7 @@ class BenchFlowDSLTest extends JUnitSuite {
 
     val expectedList = List.fill(expectedExplorationSpaceSize)(-1)
 
-    val expectedUsersState = (expectedList, explorationSpace.users.get.length)
+    val expectedUsersState = (expectedList, 4)
     val expectedMemoryState = Map(("camunda", (expectedList, 5)))
     val expectedEnvironmentState = Map(
       ("camunda", Map(

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/explorationspace/ExplorationSpaceGeneratorTest.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/explorationspace/ExplorationSpaceGeneratorTest.scala
@@ -1,0 +1,48 @@
+package cloud.benchflow.dsl.explorationspace
+
+import java.nio.file.Paths
+
+import cloud.benchflow.dsl.definition.types.bytes.Bytes
+import org.junit.{ Assert, Test }
+import org.scalatest.junit.JUnitSuite
+import cloud.benchflow.dsl.{ BenchFlowDSL, BenchFlowExplorationMultipleExample }
+
+import scala.io.Source
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com)
+ *         created on 2017-05-26
+ */
+class ExplorationSpaceGeneratorTest extends JUnitSuite {
+
+  @Test def generationTest(): Unit = {
+
+    val testYamlString = Source.fromFile(Paths.get(BenchFlowExplorationMultipleExample).toFile).mkString
+
+    val benchFlowTest = BenchFlowDSL.testFromYaml(testYamlString)
+
+    val explorationSpace = ExplorationSpaceGenerator.generateExplorationSpace(benchFlowTest)
+
+    val expectedUsersList = List(5, 10, 15, 20)
+
+    val expectedMemoryMap = Map(("camunda", List(
+      Bytes.fromString("1g").get,
+      Bytes.fromString("2g").get,
+      Bytes.fromString("3g").get,
+      Bytes.fromString("4g").get,
+      Bytes.fromString("5g").get)))
+
+    val expectedValues = List("1", "2", "3", "5")
+    val expectedEnvironmentMap = Map(("camunda", Map(("SIZE_OF_THREADPOOL", expectedValues))))
+
+    Assert.assertTrue(explorationSpace.users.isDefined)
+    Assert.assertEquals(expectedUsersList, explorationSpace.users.get)
+
+    Assert.assertTrue(explorationSpace.memory.isDefined)
+    Assert.assertEquals(expectedMemoryMap, explorationSpace.memory.get)
+
+    Assert.assertTrue(explorationSpace.environment.isDefined)
+    Assert.assertEquals(expectedEnvironmentMap, explorationSpace.environment.get)
+  }
+
+}

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/explorationspace/ExplorationSpaceGeneratorTest.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/explorationspace/ExplorationSpaceGeneratorTest.scala
@@ -32,8 +32,11 @@ class ExplorationSpaceGeneratorTest extends JUnitSuite {
       Bytes.fromString("4g").get,
       Bytes.fromString("5g").get)))
 
-    val expectedValues = List("1", "2", "3", "5")
-    val expectedEnvironmentMap = Map(("camunda", Map(("SIZE_OF_THREADPOOL", expectedValues))))
+    val tpExpectedValues = List("1", "2", "3", "5")
+    val enumExpectedValues = List("A", "B", "C")
+    val expectedEnvironmentMap = Map(("camunda", Map(
+      ("SIZE_OF_THREADPOOL", tpExpectedValues),
+      ("AN_ENUM", enumExpectedValues))))
 
     Assert.assertTrue(explorationSpace.users.isDefined)
     Assert.assertEquals(expectedUsersList, explorationSpace.users.get)
@@ -43,6 +46,22 @@ class ExplorationSpaceGeneratorTest extends JUnitSuite {
 
     Assert.assertTrue(explorationSpace.environment.isDefined)
     Assert.assertEquals(expectedEnvironmentMap, explorationSpace.environment.get)
+  }
+
+  @Test def initialExplorationSpaceTest(): Unit = {
+
+    val testYamlString = Source.fromFile(Paths.get(BenchFlowExplorationMultipleExample).toFile).mkString
+
+    val benchFlowTest = BenchFlowDSL.testFromYaml(testYamlString)
+
+    val explorationSpace = ExplorationSpaceGenerator.generateExplorationSpace(benchFlowTest)
+
+    val initialExplorationSpaceState = ExplorationSpaceGenerator.generateInitialExplorationSpaceState(explorationSpace)
+
+    val expectedExplorationSpaceSize = 5 * 4 * 3 * 4
+
+    Assert.assertEquals(expectedExplorationSpaceSize, initialExplorationSpaceState.environmentState.head.head._2.head._2._1.length)
+
   }
 
 }

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/explorationspace/ExplorationSpaceGeneratorTest.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/explorationspace/ExplorationSpaceGeneratorTest.scala
@@ -60,7 +60,11 @@ class ExplorationSpaceGeneratorTest extends JUnitSuite {
 
     val expectedExplorationSpaceSize = 5 * 4 * 3 * 4
 
-    Assert.assertEquals(expectedExplorationSpaceSize, initialExplorationSpaceState.environmentState.head.head._2.head._2._1.length)
+    Assert.assertEquals(
+      expectedExplorationSpaceSize,
+      initialExplorationSpaceState.usersState.map {
+        case (list, _) => list.length
+      }.get)
 
   }
 

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/package.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/package.scala
@@ -11,5 +11,6 @@ package object dsl {
   val BenchFlowLoadTestExample: String = BenchFlowTestExamplesFolder + "load/benchflow-test.yml"
 
   val BenchFlowExplorationUsersExample: String = BenchFlowTestExamplesFolder + "exploration/one-at-a-time/users/benchflow-test.yml"
+  val BenchFlowExplorationMultipleExample: String = BenchFlowTestExamplesFolder + "exploration/one-at-a-time/multiple/benchflow-test.yml"
 
 }

--- a/tests/data/dsl-examples/definition/benchflow-test/exploration/one-at-a-time/multiple/benchflow-test.yml
+++ b/tests/data/dsl-examples/definition/benchflow-test/exploration/one-at-a-time/multiple/benchflow-test.yml
@@ -19,6 +19,7 @@ configuration:
             range: [1g, 5g]
         environment:
           SIZE_OF_THREADPOOL: ["1","2","3","5"]
+          AN_ENUM: [A,B,C]
       workload:
         users:
           values: [5, 10, 15, 20]

--- a/tests/data/dsl-examples/definition/benchflow-test/exploration/one-at-a-time/multiple/benchflow-test.yml
+++ b/tests/data/dsl-examples/definition/benchflow-test/exploration/one-at-a-time/multiple/benchflow-test.yml
@@ -1,0 +1,96 @@
+###############################################################################
+# BenchFlow Test Definition
+###############################################################################
+version: '1'
+name: WfMSTest
+description: A WfMS test
+
+###############################################################################
+# Test Configuration
+###############################################################################
+configuration:
+  goal:
+    type: exploration
+
+    exploration_space:
+      camunda:
+        resources:
+          memory:
+            range: [1g, 5g]
+        environment:
+          SIZE_OF_THREADPOOL: ["1","2","3","5"]
+      workload:
+        users:
+          values: [5, 10, 15, 20]
+
+  strategy:
+    selection: one-at-a-time
+
+  workload_execution:
+     ramp_up: 0s
+     steady_state: 60s
+     ramp_down: 0s
+
+  termination_criteria:
+    test:
+      max_time: 1h
+
+    experiment:
+      type: fixed
+      number: 3
+
+###############################################################################
+# SUT Info Section
+###############################################################################
+sut:
+  name: camunda
+  version: 3.5.0
+  type: wfms
+
+  configuration:
+    target_service:
+      name: camunda
+      endpoint: /engine-rest
+      sut_ready_log_check: ready
+
+    deployment:
+      camunda: serverA
+      db: serverB
+
+###############################################################################
+# Workload Modeling Section
+# this is specific to the SUT type
+###############################################################################
+workload:
+  mymodel:
+    driver_type: start
+    operations:
+      - myModel.bpmn
+
+    mix:
+      fixed_sequence: [ myModel ]
+      max_deviation: 5%
+
+###############################################################################
+# Data Collection Section
+###############################################################################
+data_collection:
+  client_side:
+    faban:
+      max_run_time: 6s
+      interval: 2s
+      workload:
+        mymodel: 30s
+
+  server_side:
+    camunda: stats
+
+    db:
+      mysql:
+        environment:
+          MYSQL_DB_NAME: process-engine
+          MYSQL_USER: camunda
+          MYSQL_USER_PASSWORD: camunda
+          TABLE_NAMES: ACT_HI_PROCINST,ACT_HI_ACTINST
+          MYSQL_PORT: "3306"
+          MY_MONITOR_QUERY: complete


### PR DESCRIPTION
Adds method to generate initial exploration space from a `benchflow-test.yml`

- fixes https://github.com/benchflow/benchflow/issues/276
- adds example `benchflow-test.yml` for exploration space with multiple variables/dimensions