### PR TITLE
Adds test mode to mock Faban with basic scenarios

### DIFF
--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/BenchFlowExperimentManagerApplication.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/BenchFlowExperimentManagerApplication.java
@@ -2,6 +2,7 @@ package cloud.benchflow.experimentmanager;
 
 import cloud.benchflow.experimentmanager.configurations.BenchFlowExperimentManagerConfiguration;
 import cloud.benchflow.experimentmanager.resources.BenchFlowExperimentResource;
+import cloud.benchflow.experimentmanager.scheduler.ExperimentTaskScheduler;
 import cloud.benchflow.experimentmanager.services.external.BenchFlowTestManagerService;
 import cloud.benchflow.experimentmanager.services.external.DriversMakerService;
 import cloud.benchflow.experimentmanager.services.external.FabanManagerService;
@@ -9,11 +10,8 @@ import cloud.benchflow.experimentmanager.services.external.MinioService;
 import cloud.benchflow.experimentmanager.services.external.test.FabanManagerServiceMock;
 import cloud.benchflow.experimentmanager.services.internal.dao.BenchFlowExperimentModelDAO;
 import cloud.benchflow.experimentmanager.services.internal.dao.TrialModelDAO;
-import cloud.benchflow.experimentmanager.scheduler.ExperimentTaskScheduler;
 import cloud.benchflow.faban.client.FabanClient;
-
 import com.mongodb.MongoClient;
-
 import de.thomaskrille.dropwizard_template_config.TemplateConfigBundle;
 import de.thomaskrille.dropwizard_template_config.TemplateConfigBundleConfiguration;
 import io.dropwizard.Application;
@@ -22,11 +20,8 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.federecio.dropwizard.swagger.SwaggerBundle;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
-
 import java.util.concurrent.ExecutorService;
-
 import javax.ws.rs.client.Client;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/BenchFlowExperimentManagerApplication.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/BenchFlowExperimentManagerApplication.java
@@ -6,6 +6,7 @@ import cloud.benchflow.experimentmanager.services.external.BenchFlowTestManagerS
 import cloud.benchflow.experimentmanager.services.external.DriversMakerService;
 import cloud.benchflow.experimentmanager.services.external.FabanManagerService;
 import cloud.benchflow.experimentmanager.services.external.MinioService;
+import cloud.benchflow.experimentmanager.services.external.test.FabanManagerServiceMock;
 import cloud.benchflow.experimentmanager.services.internal.dao.BenchFlowExperimentModelDAO;
 import cloud.benchflow.experimentmanager.services.internal.dao.TrialModelDAO;
 import cloud.benchflow.experimentmanager.scheduler.ExperimentTaskScheduler;
@@ -144,9 +145,15 @@ public class BenchFlowExperimentManagerApplication
     trialModelDAO = new TrialModelDAO(mongoClient);
 
     minioService = configuration.getMinioServiceFactory().build();
-    fabanManagerService = new FabanManagerService(fabanClient);
     driversMakerService = configuration.getDriversMakerServiceFactory().build(client);
     testManagerService = configuration.getTestManagerServiceFactory().build(client);
+
+    // start in test mode or not
+    if (configuration.getTestModeFactory().isMockFaban()) {
+      fabanManagerService = new FabanManagerServiceMock(fabanClient);
+    } else {
+      fabanManagerService = new FabanManagerService(fabanClient);
+    }
 
     experimentTaskScheduler = new ExperimentTaskScheduler(experimentTaskExecutorService);
 

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/api/request/BenchFlowExperimentStateRequest.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/api/request/BenchFlowExperimentStateRequest.java
@@ -3,9 +3,7 @@ package cloud.benchflow.experimentmanager.api.request;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.BenchFlowExperimentState;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.RunningState;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.TerminatedState;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import javax.validation.constraints.NotNull;
 
 /**

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/api/request/SubmitTrialStatusRequest.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/api/request/SubmitTrialStatusRequest.java
@@ -1,9 +1,7 @@
 package cloud.benchflow.experimentmanager.api.request;
 
 import cloud.benchflow.faban.client.responses.RunStatus;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import javax.validation.constraints.NotNull;
 
 /**

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/api/response/BenchFlowExperimentStateResponse.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/api/response/BenchFlowExperimentStateResponse.java
@@ -1,9 +1,7 @@
 package cloud.benchflow.experimentmanager.api.response;
 
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/BenchFlowExperimentManagerConfiguration.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/BenchFlowExperimentManagerConfiguration.java
@@ -8,6 +8,7 @@ import cloud.benchflow.experimentmanager.configurations.factory.MongoDBFactory;
 import cloud.benchflow.experimentmanager.configurations.factory.TaskExecutorFactory;
 import cloud.benchflow.experimentmanager.configurations.factory.TestManagerServiceFactory;
 
+import cloud.benchflow.experimentmanager.configurations.factory.TestModeFactory;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.dropwizard.Configuration;
@@ -155,4 +156,18 @@ public class BenchFlowExperimentManagerConfiguration extends Configuration {
     this.experimentTaskExecutorServiceFactory = taskExecutorServiceFactory;
   }
 
+  // Test Mode
+  @Valid
+  @NotNull
+  private TestModeFactory testModeFactory = new TestModeFactory();
+
+  @JsonProperty("testMode")
+  public TestModeFactory getTestModeFactory() {
+    return testModeFactory;
+  }
+
+  @JsonProperty("testMode")
+  public void setTestModeFactory(TestModeFactory testModeFactory) {
+    this.testModeFactory = testModeFactory;
+  }
 }

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/BenchFlowExperimentManagerConfiguration.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/BenchFlowExperimentManagerConfiguration.java
@@ -7,25 +7,60 @@ import cloud.benchflow.experimentmanager.configurations.factory.MinioServiceFact
 import cloud.benchflow.experimentmanager.configurations.factory.MongoDBFactory;
 import cloud.benchflow.experimentmanager.configurations.factory.TaskExecutorFactory;
 import cloud.benchflow.experimentmanager.configurations.factory.TestManagerServiceFactory;
-
 import cloud.benchflow.experimentmanager.configurations.factory.TestModeFactory;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 public class BenchFlowExperimentManagerConfiguration extends Configuration {
 
   // see http://www.dropwizard.io/1.0.6/docs/manual/core.html#configuration
-
-  // Jersey Client Configuration
   @Valid
   @NotNull
   private JerseyClientConfiguration jerseyClient = new JerseyClientConfiguration();
+
+  @Valid
+  @NotNull
+  private final SwaggerBundleConfiguration swagger = new SwaggerBundleConfiguration();
+
+  @Valid
+  @NotNull
+  @JsonProperty
+  private BenchFlowEnvironmentFactory benchFlowEnvironmentFactory =
+      new BenchFlowEnvironmentFactory();
+
+  @Valid
+  @NotNull
+  private MongoDBFactory mongoDBFactory = new MongoDBFactory();
+
+  @Valid
+  @NotNull
+  @JsonProperty
+  private MinioServiceFactory minioServiceFactory = new MinioServiceFactory();
+
+  @Valid
+  @NotNull
+  private FabanServiceFactory fabanServiceFactory = new FabanServiceFactory();
+
+  @Valid
+  @NotNull
+  private DriversMakerServiceFactory driversMakerServiceFactory = new DriversMakerServiceFactory();
+
+  @Valid
+  @NotNull
+  private TestManagerServiceFactory testManagerServiceFactory = new TestManagerServiceFactory();
+
+  @Valid
+  @NotNull
+  private TaskExecutorFactory experimentTaskExecutorServiceFactory = new TaskExecutorFactory();
+
+  @Valid
+  @NotNull
+  private TestModeFactory testModeFactory = new TestModeFactory();
+
 
   @JsonProperty("jerseyClient")
   public JerseyClientConfiguration getJerseyClientConfiguration() {
@@ -37,38 +72,23 @@ public class BenchFlowExperimentManagerConfiguration extends Configuration {
     this.jerseyClient = jerseyClient;
   }
 
-  // Swagger Configuration
-  @Valid
-  @NotNull
-  private final SwaggerBundleConfiguration swagger = new SwaggerBundleConfiguration();
 
   @JsonProperty("swagger")
   public SwaggerBundleConfiguration getSwagger() {
     return swagger;
   }
 
-  // BenchFlow Environment Configuration
-  @Valid
-  @NotNull
-  @JsonProperty
-  private BenchFlowEnvironmentFactory benchFlowEnvironmentFactory =
-      new BenchFlowEnvironmentFactory();
 
   @JsonProperty("benchFlowEnvironment")
   public BenchFlowEnvironmentFactory getBenchFlowEnvironmentFactory() {
     return benchFlowEnvironmentFactory;
   }
-
   @JsonProperty("benchFlowEnvironment")
   public void setBenchFlowEnvironmentFactory(
       BenchFlowEnvironmentFactory benchFlowEnvironmentFactory) {
     this.benchFlowEnvironmentFactory = benchFlowEnvironmentFactory;
   }
 
-  // MongoDB Configuration
-  @Valid
-  @NotNull
-  private MongoDBFactory mongoDBFactory = new MongoDBFactory();
 
   @JsonProperty("mongoDB")
   public MongoDBFactory getMongoDBFactory() {
@@ -80,11 +100,6 @@ public class BenchFlowExperimentManagerConfiguration extends Configuration {
     this.mongoDBFactory = mongoDBFactory;
   }
 
-  // Minio Service
-  @Valid
-  @NotNull
-  @JsonProperty
-  private MinioServiceFactory minioServiceFactory = new MinioServiceFactory();
 
   @JsonProperty("minio")
   public MinioServiceFactory getMinioServiceFactory() {
@@ -96,10 +111,6 @@ public class BenchFlowExperimentManagerConfiguration extends Configuration {
     this.minioServiceFactory = minioServiceFactory;
   }
 
-  // Faban
-  @Valid
-  @NotNull
-  private FabanServiceFactory fabanServiceFactory = new FabanServiceFactory();
 
   @JsonProperty("faban")
   public FabanServiceFactory getFabanServiceFactory() {
@@ -111,10 +122,6 @@ public class BenchFlowExperimentManagerConfiguration extends Configuration {
     this.fabanServiceFactory = fabanServiceFactory;
   }
 
-  // Drivers Maker
-  @Valid
-  @NotNull
-  private DriversMakerServiceFactory driversMakerServiceFactory = new DriversMakerServiceFactory();
 
   @JsonProperty("driversMaker")
   public DriversMakerServiceFactory getDriversMakerServiceFactory() {
@@ -126,25 +133,18 @@ public class BenchFlowExperimentManagerConfiguration extends Configuration {
     this.driversMakerServiceFactory = driversMakerServiceFactory;
   }
 
-  // Performance-Test-Manager Service
-  @Valid
-  @NotNull
-  private TestManagerServiceFactory testManagerServiceFactory = new TestManagerServiceFactory();
 
   @JsonProperty("testManager")
   public TestManagerServiceFactory getTestManagerServiceFactory() {
     return testManagerServiceFactory;
   }
 
+
   @JsonProperty("testManager")
   public void setTestManagerServiceFactory(TestManagerServiceFactory testManagerServiceFactory) {
     this.testManagerServiceFactory = testManagerServiceFactory;
   }
 
-  // Experiment Task Executor
-  @Valid
-  @NotNull
-  private TaskExecutorFactory experimentTaskExecutorServiceFactory = new TaskExecutorFactory();
 
   @JsonProperty("experimentTaskExecutor")
   public TaskExecutorFactory getExperimentTaskExecutorFactory() {
@@ -156,10 +156,6 @@ public class BenchFlowExperimentManagerConfiguration extends Configuration {
     this.experimentTaskExecutorServiceFactory = taskExecutorServiceFactory;
   }
 
-  // Test Mode
-  @Valid
-  @NotNull
-  private TestModeFactory testModeFactory = new TestModeFactory();
 
   @JsonProperty("testMode")
   public TestModeFactory getTestModeFactory() {

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/BenchFlowExperimentManagerConfiguration.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/BenchFlowExperimentManagerConfiguration.java
@@ -83,6 +83,7 @@ public class BenchFlowExperimentManagerConfiguration extends Configuration {
   public BenchFlowEnvironmentFactory getBenchFlowEnvironmentFactory() {
     return benchFlowEnvironmentFactory;
   }
+
   @JsonProperty("benchFlowEnvironment")
   public void setBenchFlowEnvironmentFactory(
       BenchFlowEnvironmentFactory benchFlowEnvironmentFactory) {

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/BenchFlowEnvironmentFactory.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/BenchFlowEnvironmentFactory.java
@@ -1,7 +1,6 @@
 package cloud.benchflow.experimentmanager.configurations.factory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/DriversMakerServiceFactory.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/DriversMakerServiceFactory.java
@@ -1,11 +1,8 @@
 package cloud.benchflow.experimentmanager.configurations.factory;
 
 import cloud.benchflow.experimentmanager.services.external.DriversMakerService;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import javax.ws.rs.client.Client;
-
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/FabanServiceFactory.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/FabanServiceFactory.java
@@ -2,14 +2,10 @@ package cloud.benchflow.experimentmanager.configurations.factory;
 
 import cloud.benchflow.faban.client.FabanClient;
 import cloud.benchflow.faban.client.configurations.FabanClientConfigImpl;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import javax.validation.constraints.NotNull;
-
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/MinioServiceFactory.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/MinioServiceFactory.java
@@ -1,13 +1,10 @@
 package cloud.benchflow.experimentmanager.configurations.factory;
 
 import cloud.benchflow.experimentmanager.services.external.MinioService;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.minio.MinioClient;
 import io.minio.errors.InvalidEndpointException;
 import io.minio.errors.InvalidPortException;
-
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/MongoDBFactory.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/MongoDBFactory.java
@@ -2,10 +2,8 @@ package cloud.benchflow.experimentmanager.configurations.factory;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mongodb.MongoClient;
-
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/TaskExecutorFactory.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/TaskExecutorFactory.java
@@ -3,15 +3,14 @@ package cloud.benchflow.experimentmanager.configurations.factory;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.util.Duration;
-
-import javax.annotation.Nonnull;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 
 /**
  * @author Simone D'Avico (simonedavico@gmail.com)

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/TestManagerServiceFactory.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/TestManagerServiceFactory.java
@@ -1,11 +1,8 @@
 package cloud.benchflow.experimentmanager.configurations.factory;
 
 import cloud.benchflow.experimentmanager.services.external.BenchFlowTestManagerService;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import javax.ws.rs.client.Client;
-
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/TestModeFactory.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/TestModeFactory.java
@@ -9,7 +9,7 @@ import javax.validation.constraints.NotNull;
 public class TestModeFactory {
 
   @NotNull
-  boolean mockFaban;
+  private boolean mockFaban;
 
   @JsonProperty
   public boolean isMockFaban() {

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/TestModeFactory.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/configurations/factory/TestModeFactory.java
@@ -1,0 +1,23 @@
+package cloud.benchflow.experimentmanager.configurations.factory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.constraints.NotNull;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-06-04
+ */
+public class TestModeFactory {
+
+  @NotNull
+  boolean mockFaban;
+
+  @JsonProperty
+  public boolean isMockFaban() {
+    return mockFaban;
+  }
+
+  @JsonProperty
+  public void setMockFaban(boolean mockFaban) {
+    this.mockFaban = mockFaban;
+  }
+}

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/constants/BenchFlowConstants.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/constants/BenchFlowConstants.java
@@ -76,6 +76,14 @@ public class BenchFlowConstants {
     return Integer.parseInt(trialNumber);
   }
 
+  public static String getTestNameFromTrialID(String trialID) {
+
+    String[] trialIDArray = trialID.split(MODEL_ID_DELIMITER_REGEX);
+
+    return trialIDArray[1];
+
+  }
+
   public static String getTrialID(String experimentID, long trialNumber) {
     return experimentID + BenchFlowConstants.MODEL_ID_DELIMITER + trialNumber;
   }

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/models/BenchFlowExperimentModel.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/models/BenchFlowExperimentModel.java
@@ -2,7 +2,6 @@ package cloud.benchflow.experimentmanager.models;
 
 import java.util.Date;
 import java.util.TreeMap;
-
 import org.mongodb.morphia.annotations.Entity;
 import org.mongodb.morphia.annotations.Field;
 import org.mongodb.morphia.annotations.Id;

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/models/TrialModel.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/models/TrialModel.java
@@ -3,9 +3,7 @@ package cloud.benchflow.experimentmanager.models;
 import static cloud.benchflow.experimentmanager.models.TrialModel.HandleTrialResultState.CHECK_TRIAL_RESULT;
 
 import cloud.benchflow.faban.client.responses.RunStatus;
-
 import java.util.Date;
-
 import org.mongodb.morphia.annotations.Entity;
 import org.mongodb.morphia.annotations.Field;
 import org.mongodb.morphia.annotations.Id;

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/resources/BenchFlowExperimentResource.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/resources/BenchFlowExperimentResource.java
@@ -6,11 +6,10 @@ import cloud.benchflow.experimentmanager.api.response.BenchFlowExperimentStateRe
 import cloud.benchflow.experimentmanager.constants.BenchFlowConstants;
 import cloud.benchflow.experimentmanager.exceptions.BenchFlowExperimentIDDoesNotExistException;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel;
+import cloud.benchflow.experimentmanager.scheduler.ExperimentTaskScheduler;
 import cloud.benchflow.experimentmanager.services.external.MinioService;
 import cloud.benchflow.experimentmanager.services.internal.dao.BenchFlowExperimentModelDAO;
-import cloud.benchflow.experimentmanager.scheduler.ExperimentTaskScheduler;
 import io.swagger.annotations.Api;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
@@ -23,7 +22,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/external/BenchFlowTestManagerService.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/external/BenchFlowTestManagerService.java
@@ -7,13 +7,11 @@ import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.BenchFlowExperimentState;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.RunningState;
 import cloud.benchflow.faban.client.responses.RunStatus;
-
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/external/DriversMakerService.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/external/DriversMakerService.java
@@ -3,13 +3,11 @@ package cloud.benchflow.experimentmanager.services.external;
 import static cloud.benchflow.experimentmanager.constants.BenchFlowConstants.MODEL_ID_DELIMITER;
 
 import cloud.benchflow.experimentmanager.exceptions.web.BenchmarkGenerationException;
-
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/external/MinioService.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/external/MinioService.java
@@ -18,14 +18,12 @@ import io.minio.errors.InvalidArgumentException;
 import io.minio.errors.InvalidBucketNameException;
 import io.minio.errors.MinioException;
 import io.minio.errors.NoResponseException;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/external/test/FabanManagerServiceMock.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/external/test/FabanManagerServiceMock.java
@@ -1,0 +1,110 @@
+package cloud.benchflow.experimentmanager.services.external.test;
+
+import cloud.benchflow.experimentmanager.constants.BenchFlowConstants;
+import cloud.benchflow.experimentmanager.services.external.FabanManagerService;
+import cloud.benchflow.experimentmanager.tasks.running.execute.ExecuteTrial.TrialStatus;
+import cloud.benchflow.faban.client.FabanClient;
+import cloud.benchflow.faban.client.exceptions.JarFileNotFoundException;
+import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
+import cloud.benchflow.faban.client.responses.RunId;
+import cloud.benchflow.faban.client.responses.RunStatus.Code;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-06-04
+ */
+public class FabanManagerServiceMock extends FabanManagerService {
+
+  private static final String SCENARIO_ALWAYS_COMPLETED = "alwayscompleted";
+  private static final String SCENARIO_FAIL_FIRST_EXECUTION = "failfirstexecution";
+
+  private static Logger logger =
+      LoggerFactory.getLogger(FabanManagerServiceMock.class.getSimpleName());
+
+  private Map<String, Integer> runIdMap = new HashMap<>();
+
+  private long runIdCounter = 0;
+
+  public FabanManagerServiceMock(FabanClient fabanClient) {
+    super(fabanClient);
+  }
+
+  @Override
+  public void deployExperimentToFaban(String experimentID, String driversMakerExperimentID,
+      long experimentNumber) throws IOException, JarFileNotFoundException {
+    // we do not do anything here since there is no need to deploy
+    logger.info("deployExperimentToFaban: " + experimentID);
+  }
+
+  @Override
+  public RunId submitTrialToFaban(String experimentID, String trialID,
+      String driversMakerExperimentID, long experimentNumber) throws IOException {
+
+    logger.info("submitTrialToFaban: " + trialID);
+
+    // here we need to create a RunId and also store that so that we can control what to return
+    String fabanID = getFabanTrialID(trialID);
+
+    RunId runId = new RunId(fabanID, Long.toString(runIdCounter++));
+
+    if (!runIdMap.containsKey(trialID)) {
+      runIdMap.put(trialID, 1);
+    } else {
+      runIdMap.put(trialID, runIdMap.get(trialID) + 1);
+    }
+
+    return runId;
+
+  }
+
+  @Override
+  public TrialStatus pollForTrialStatus(String trialID, RunId runId) throws RunIdNotFoundException {
+
+    logger.info("pollForTrialStatus: " + trialID);
+
+    // here we need to return a TrialStatus depending on the scenario
+
+    String scenario = BenchFlowConstants.getTestNameFromTrialID(trialID);
+
+    TrialStatus trialStatus;
+
+    switch (scenario.toLowerCase()) {
+
+      case SCENARIO_ALWAYS_COMPLETED:
+
+        trialStatus = new TrialStatus(trialID, Code.COMPLETED);
+
+        break;
+
+      case SCENARIO_FAIL_FIRST_EXECUTION:
+
+        trialStatus = handleFailFirstExecution(trialID);
+        break;
+
+      default:
+        // no scenario defined so we fail
+        trialStatus = new TrialStatus(trialID, Code.FAILED);
+        break;
+
+    }
+
+    return trialStatus;
+
+  }
+
+  private TrialStatus handleFailFirstExecution(String trialID) {
+
+    int numExecutions = runIdMap.get(trialID);
+
+    if (numExecutions < 2) {
+      return new TrialStatus(trialID, Code.FAILED);
+    }
+
+    return new TrialStatus(trialID, Code.COMPLETED);
+
+  }
+}

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/external/test/FabanManagerServiceMock.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/external/test/FabanManagerServiceMock.java
@@ -19,8 +19,15 @@ import org.slf4j.LoggerFactory;
  */
 public class FabanManagerServiceMock extends FabanManagerService {
 
+  // the scenarios can be expressed using any case (upper,lower, camel...)
+  // however in order to be used in the switch statement we can only use on case
+  // by converting the received test name to lower case we can match with
+  // the strings below
+
+  // default if test name doesn't match any scenario
   private static final String SCENARIO_ALWAYS_COMPLETED = "alwayscompleted";
   private static final String SCENARIO_FAIL_FIRST_EXECUTION = "failfirstexecution";
+  private static final String SCENARIO_ALWAYS_FAIL = "alwaysfail";
 
   private static Logger logger =
       LoggerFactory.getLogger(FabanManagerServiceMock.class.getSimpleName());
@@ -74,9 +81,9 @@ public class FabanManagerServiceMock extends FabanManagerService {
 
     switch (scenario.toLowerCase()) {
 
-      case SCENARIO_ALWAYS_COMPLETED:
+      case SCENARIO_ALWAYS_FAIL:
 
-        trialStatus = new TrialStatus(trialID, Code.COMPLETED);
+        trialStatus = new TrialStatus(trialID, Code.FAILED);
 
         break;
 
@@ -85,9 +92,11 @@ public class FabanManagerServiceMock extends FabanManagerService {
         trialStatus = handleFailFirstExecution(trialID);
         break;
 
+      case SCENARIO_ALWAYS_COMPLETED:
       default:
-        // no scenario defined so we fail
-        trialStatus = new TrialStatus(trialID, Code.FAILED);
+
+        trialStatus = new TrialStatus(trialID, Code.COMPLETED);
+
         break;
 
     }

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/internal/dao/AbstractDAO.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/internal/dao/AbstractDAO.java
@@ -3,9 +3,7 @@ package cloud.benchflow.experimentmanager.services.internal.dao;
 import cloud.benchflow.experimentmanager.constants.BenchFlowConstants;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel;
 import cloud.benchflow.experimentmanager.models.TrialModel;
-
 import com.mongodb.MongoClient;
-
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.Morphia;
 

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/internal/dao/BenchFlowExperimentModelDAO.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/services/internal/dao/BenchFlowExperimentModelDAO.java
@@ -9,9 +9,7 @@ import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.BenchFl
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.FailureStatus;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.RunningState;
 import cloud.benchflow.experimentmanager.models.TrialModel;
-
 import com.mongodb.MongoClient;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/tasks/running/DetermineAndExecuteTrialsTask.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/tasks/running/DetermineAndExecuteTrialsTask.java
@@ -7,9 +7,7 @@ import cloud.benchflow.experimentmanager.services.internal.dao.BenchFlowExperime
 import cloud.benchflow.experimentmanager.services.internal.dao.TrialModelDAO;
 import cloud.benchflow.experimentmanager.tasks.running.execute.ExecuteTrial;
 import cloud.benchflow.experimentmanager.tasks.running.execute.ExecuteTrial.TrialStatus;
-
 import java.util.concurrent.Callable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/BenchFlowExperimentManagerApplicationIT.java
+++ b/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/BenchFlowExperimentManagerApplicationIT.java
@@ -8,8 +8,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 
 import cloud.benchflow.experimentmanager.configurations.BenchFlowExperimentManagerConfiguration;
 import cloud.benchflow.experimentmanager.constants.BenchFlowConstants;
-import cloud.benchflow.experimentmanager.helpers.MinioTestData;
 import cloud.benchflow.experimentmanager.helpers.BenchFlowData;
+import cloud.benchflow.experimentmanager.helpers.MinioTestData;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.BenchFlowExperimentState;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.TerminatedState;
 import cloud.benchflow.experimentmanager.resources.BenchFlowExperimentResource;
@@ -22,20 +22,15 @@ import cloud.benchflow.faban.client.FabanClient;
 import cloud.benchflow.faban.client.responses.DeployStatus;
 import cloud.benchflow.faban.client.responses.RunId;
 import cloud.benchflow.faban.client.responses.RunStatus;
-
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
-
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-
 import java.io.File;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,10 +61,11 @@ public class BenchFlowExperimentManagerApplicationIT extends DockerComposeIT {
   @Rule
   public WireMockRule wireMockRule = new WireMockRule(TEST_PORT);
 
-  private String experimentID = BenchFlowData.VALID_EXPERIMENT_ID_1_TRIAL;
   private MinioService minioServiceSpy;
   private FabanClient fabanClientSpy;
   private ExecutorService executorService;
+
+  private String experimentID = BenchFlowData.VALID_EXPERIMENT_ID_1_TRIAL;
 
   @Before
   public void setUp() throws Exception {
@@ -99,6 +95,8 @@ public class BenchFlowExperimentManagerApplicationIT extends DockerComposeIT {
         MinioTestData.getDeploymentDescriptor());
     minioServiceSpy.saveExperimentBPMNModel(experimentID, MinioTestData.BPM_MODEL_11_PARALLEL_NAME,
         MinioTestData.get11ParallelStructuredModel());
+    minioServiceSpy.saveExperimentBPMNModel(experimentID, MinioTestData.BPM_MODEL_MOCK_NAME,
+        MinioTestData.getMockModel());
 
     // make sure also drivers-maker benchmark is returned
     Mockito.doReturn(MinioTestData.getGeneratedBenchmark()).when(minioServiceSpy)

--- a/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/BenchFlowExperimentManagerApplicationTestModeIT.java
+++ b/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/BenchFlowExperimentManagerApplicationTestModeIT.java
@@ -1,0 +1,231 @@
+package cloud.benchflow.experimentmanager;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+import cloud.benchflow.experimentmanager.configurations.BenchFlowExperimentManagerConfiguration;
+import cloud.benchflow.experimentmanager.constants.BenchFlowConstants;
+import cloud.benchflow.experimentmanager.helpers.BenchFlowData;
+import cloud.benchflow.experimentmanager.helpers.MinioTestData;
+import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.BenchFlowExperimentState;
+import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel.TerminatedState;
+import cloud.benchflow.experimentmanager.resources.BenchFlowExperimentResource;
+import cloud.benchflow.experimentmanager.services.external.BenchFlowTestManagerService;
+import cloud.benchflow.experimentmanager.services.external.DriversMakerService;
+import cloud.benchflow.experimentmanager.services.external.MinioService;
+import cloud.benchflow.experimentmanager.services.internal.dao.BenchFlowExperimentModelDAO;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.io.FileNotFoundException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-06-04
+ */
+public class BenchFlowExperimentManagerApplicationTestModeIT
+    extends DockerComposeIT {
+
+  private static final int TEST_PORT = 8080;
+  private static final String TEST_ADDRESS = "localhost:" + TEST_PORT;
+
+  @Rule
+  public final DropwizardAppRule<BenchFlowExperimentManagerConfiguration> RULE =
+      new DropwizardAppRule<>(BenchFlowExperimentManagerApplication.class, "../configuration.yml",
+          ConfigOverride.config("mongoDB.hostname", MONGO_CONTAINER.getIp()),
+          ConfigOverride.config("mongoDB.port", String.valueOf(MONGO_CONTAINER.getExternalPort())),
+          ConfigOverride.config("minio.address",
+              "http://" + MINIO_CONTAINER.getIp() + ":" + MINIO_CONTAINER.getExternalPort()),
+          ConfigOverride.config("minio.accessKey", MINIO_ACCESS_KEY),
+          ConfigOverride.config("minio.secretKey", MINIO_SECRET_KEY),
+          ConfigOverride.config("driversMaker.address", TEST_ADDRESS),
+          ConfigOverride.config("testManager.address", TEST_ADDRESS),
+          ConfigOverride.config("faban.address", TEST_ADDRESS),
+          ConfigOverride.config("testMode.mockFaban", "true"));
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(TEST_PORT);
+
+  private MinioService minioServiceSpy;
+  private ExecutorService executorService;
+  private Client client;
+
+
+  @Before
+  public void setUp() throws Exception {
+    minioServiceSpy = Mockito.spy(BenchFlowExperimentManagerApplication.getMinioService());
+    BenchFlowExperimentManagerApplication.setMinioService(minioServiceSpy);
+
+    executorService = BenchFlowExperimentManagerApplication.getExperimentTaskScheduler()
+        .getExperimentTaskExecutorService();
+
+    client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
+  }
+
+  @Test
+  public void runScenarioAlwaysCompleted() throws Exception {
+
+    String experimentID = BenchFlowData.SCENARIO_ALWAYS_COMPLETED_EXPERIMENT_ID;
+
+    setUpMocks(experimentID);
+
+    Response response = client.target(String.format("http://localhost:%d", RULE.getLocalPort()))
+        .path(BenchFlowConstants.getPathFromExperimentID(experimentID))
+        .path(BenchFlowExperimentResource.RUN_ACTION_PATH).request().post(null);
+
+    Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+
+    BenchFlowExperimentModelDAO experimentModelDAO = new BenchFlowExperimentModelDAO(mongoClient);
+
+    Assert.assertNotNull(experimentModelDAO.getExperimentModel(experimentID));
+
+    // wait long enough for tasks to start to be executed
+    executorService.awaitTermination(2, TimeUnit.SECONDS);
+
+    Assert.assertEquals(BenchFlowExperimentState.TERMINATED,
+        experimentModelDAO.getExperimentState(experimentID));
+    Assert.assertEquals(TerminatedState.COMPLETED,
+        experimentModelDAO.getTerminatedState(experimentID));
+
+    long expectedExecutedTrials = 2;
+    long executedTrials = BenchFlowExperimentManagerApplication.getExperimentModelDAO()
+        .getNumExecutedTrials(experimentID);
+
+    Assert.assertEquals(expectedExecutedTrials, executedTrials);
+
+  }
+
+  @Test
+  public void runScenarioFailFirstExecution() throws Exception {
+
+    String experimentID = BenchFlowData.SCENARIO_FAIL_FIRST_EXEC_EXPERIMENT_ID;
+
+    setUpMocks(experimentID);
+
+    Response response = client.target(String.format("http://localhost:%d", RULE.getLocalPort()))
+        .path(BenchFlowConstants.getPathFromExperimentID(experimentID))
+        .path(BenchFlowExperimentResource.RUN_ACTION_PATH).request().post(null);
+
+    Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+
+    BenchFlowExperimentModelDAO experimentModelDAO = new BenchFlowExperimentModelDAO(mongoClient);
+
+    Assert.assertNotNull(experimentModelDAO.getExperimentModel(experimentID));
+
+    // wait long enough for tasks to start to be executed
+    executorService.awaitTermination(2, TimeUnit.SECONDS);
+
+    Assert.assertEquals(BenchFlowExperimentState.TERMINATED,
+        experimentModelDAO.getExperimentState(experimentID));
+    Assert.assertEquals(TerminatedState.COMPLETED,
+        experimentModelDAO.getTerminatedState(experimentID));
+
+    // assert expected number of executions
+    long expectedExecutedTrials = 2;
+    long executedTrials = BenchFlowExperimentManagerApplication.getExperimentModelDAO()
+        .getNumExecutedTrials(experimentID);
+
+    Assert.assertEquals(expectedExecutedTrials, executedTrials);
+
+    // assert that retries is 1
+    int numTrials = 2;
+    int expectedNumRetries = 1;
+
+    for (int i = 1; i <= numTrials; i++) {
+      int numRetries = BenchFlowExperimentManagerApplication.getTrialModelDAO()
+          .getNumRetries(experimentID + BenchFlowConstants.MODEL_ID_DELIMITER + i);
+
+      Assert.assertEquals(expectedNumRetries, numRetries);
+    }
+
+  }
+
+  @Test
+  public void runNoScenario() throws Exception {
+
+    String experimentID = BenchFlowData.NO_SCENARIO_EXPERIMENT_ID;
+
+    setUpMocks(experimentID);
+
+    Response response = client.target(String.format("http://localhost:%d", RULE.getLocalPort()))
+        .path(BenchFlowConstants.getPathFromExperimentID(experimentID))
+        .path(BenchFlowExperimentResource.RUN_ACTION_PATH).request().post(null);
+
+    Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+
+    BenchFlowExperimentModelDAO experimentModelDAO = new BenchFlowExperimentModelDAO(mongoClient);
+
+    Assert.assertNotNull(experimentModelDAO.getExperimentModel(experimentID));
+
+    // wait long enough for tasks to start to be executed
+    executorService.awaitTermination(2, TimeUnit.SECONDS);
+
+    Assert.assertEquals(BenchFlowExperimentState.TERMINATED,
+        experimentModelDAO.getExperimentState(experimentID));
+    Assert.assertEquals(TerminatedState.FAILURE,
+        experimentModelDAO.getTerminatedState(experimentID));
+
+    long expectedExecutedTrials = 1;
+    long executedTrials = BenchFlowExperimentManagerApplication.getExperimentModelDAO()
+        .getNumExecutedTrials(experimentID);
+
+    Assert.assertEquals(expectedExecutedTrials, executedTrials);
+
+  }
+
+  private void setUpMocks(String experimentID) throws FileNotFoundException {
+
+    int numTrials = 2;
+
+    // make sure experiment has been saved to minio
+    minioServiceSpy.saveExperimentDefinition(experimentID,
+        MinioTestData.getExperiment2TrialsDefinition());
+    minioServiceSpy.saveExperimentDeploymentDescriptor(experimentID,
+        MinioTestData.getDeploymentDescriptor());
+    minioServiceSpy.saveExperimentBPMNModel(experimentID, MinioTestData.BPM_MODEL_11_PARALLEL_NAME,
+        MinioTestData.get11ParallelStructuredModel());
+    minioServiceSpy.saveExperimentBPMNModel(experimentID, MinioTestData.BPM_MODEL_MOCK_NAME,
+        MinioTestData.getMockModel());
+
+    // make sure also drivers-maker benchmark is returned
+    Mockito.doReturn(MinioTestData.getGeneratedBenchmark()).when(minioServiceSpy)
+        .getDriversMakerGeneratedBenchmark(Mockito.anyString(), Mockito.anyLong());
+
+    // make sure also faban configuration file is returned
+    Mockito.doReturn(MinioTestData.getFabanConfiguration()).when(minioServiceSpy)
+        .getDriversMakerGeneratedFabanConfiguration(Mockito.anyString(), Mockito.anyLong(),
+            Mockito.anyLong());
+
+    // Drivers Maker Stub
+    stubFor(post(urlEqualTo(DriversMakerService.GENERATE_BENCHMARK_PATH))
+        .willReturn(aResponse().withStatus(Response.Status.OK.getStatusCode())));
+
+    for (int i = 1; i <= numTrials; i++) {
+
+      String trialID = experimentID + BenchFlowConstants.MODEL_ID_DELIMITER + i;
+
+      // Test Manager Trial Status Stub
+      stubFor(put(urlEqualTo(BenchFlowConstants.getPathFromTrialID(trialID)
+          + BenchFlowTestManagerService.TRIAL_STATUS_PATH))
+              .willReturn(aResponse().withStatus(Response.Status.NO_CONTENT.getStatusCode())));
+    }
+
+    // Test Manager Experiment State Stub
+    stubFor(put(urlEqualTo(BenchFlowConstants.getPathFromExperimentID(experimentID)
+        + BenchFlowTestManagerService.EXPERIMENT_STATE_PATH))
+            .willReturn(aResponse().withStatus(Response.Status.NO_CONTENT.getStatusCode())));
+
+  }
+}

--- a/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/DockerComposeIT.java
+++ b/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/DockerComposeIT.java
@@ -6,10 +6,8 @@ import com.palantir.docker.compose.DockerComposeRule;
 import com.palantir.docker.compose.connection.DockerMachine;
 import com.palantir.docker.compose.connection.DockerPort;
 import com.palantir.docker.compose.connection.waiting.HealthChecks;
-
 import java.io.File;
 import java.io.IOException;
-
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;

--- a/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/constants/BenchFlowConstantsTest.java
+++ b/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/constants/BenchFlowConstantsTest.java
@@ -1,7 +1,6 @@
 package cloud.benchflow.experimentmanager.constants;
 
 import cloud.benchflow.experimentmanager.helpers.BenchFlowData;
-
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/demo/HashingTest.java
+++ b/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/demo/HashingTest.java
@@ -4,7 +4,6 @@ import static cloud.benchflow.experimentmanager.constants.BenchFlowConstants.MIN
 import static cloud.benchflow.experimentmanager.constants.BenchFlowConstants.MODEL_ID_DELIMITER;
 
 import cloud.benchflow.experimentmanager.helpers.BenchFlowData;
-
 import org.junit.Test;
 
 /**

--- a/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/helpers/BenchFlowData.java
+++ b/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/helpers/BenchFlowData.java
@@ -15,7 +15,8 @@ public class BenchFlowData {
       "benchflow.ParallelMultiple11Activiti5210Test2Trial.1";
 
   public static String SCENARIO_ALWAYS_COMPLETED_EXPERIMENT_ID = "benchflow.alwaysCompleted.1.1";
-  public static String SCENARIO_FAIL_FIRST_EXEC_EXPERIMENT_ID = "benchflow.failfirstexecution.1.1";
+  public static String SCENARIO_FAIL_FIRST_EXEC_EXPERIMENT_ID = "benchflow.failFirstExecution.1.1";
+  public static String SCENARIO_ALWAYS_FAIL_EXPERIMENT_ID = "benchflow.alwaysFail.1.1";
   public static String NO_SCENARIO_EXPERIMENT_ID = "benchflow.noScenario.1.1";
 
   public static final String VALID_EXPERIMENT_ID_1_TRIAL =

--- a/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/helpers/BenchFlowData.java
+++ b/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/helpers/BenchFlowData.java
@@ -14,6 +14,10 @@ public class BenchFlowData {
   public static String VALID_TEST_ID_2_TRIAL =
       "benchflow.ParallelMultiple11Activiti5210Test2Trial.1";
 
+  public static String SCENARIO_ALWAYS_COMPLETED_EXPERIMENT_ID = "benchflow.alwaysCompleted.1.1";
+  public static String SCENARIO_FAIL_FIRST_EXEC_EXPERIMENT_ID = "benchflow.failfirstexecution.1.1";
+  public static String NO_SCENARIO_EXPERIMENT_ID = "benchflow.noScenario.1.1";
+
   public static final String VALID_EXPERIMENT_ID_1_TRIAL =
       VALID_TEST_ID_1_TRIAL + BenchFlowConstants.MODEL_ID_DELIMITER + EXPERIMENT_NUMBER;
   public static final String VALID_EXPERIMENT_ID_2_TRIAL =

--- a/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/helpers/MinioTestData.java
+++ b/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/helpers/MinioTestData.java
@@ -9,6 +9,9 @@ import java.io.InputStream;
  */
 public class MinioTestData {
 
+  public static final String BPM_MODEL_11_PARALLEL_NAME = "11ParallelStructured.bpmn";
+  public static final String BPM_MODEL_MOCK_NAME = "mock.bpmn";
+
   private static final String EXPERIMENT_1_TRIAL_DEFINITION_FILENAME =
       "src/test/resources/data/ParallelMultiple11/1-trials/benchflow-test.yml";
   private static final String EXPERIMENT_2_TRIALS_DEFINITION_FILENAME =
@@ -16,13 +19,13 @@ public class MinioTestData {
   private static final String DEPLOYMENT_DESCRIPTOR_FILENAME =
       "src/test/resources/data/ParallelMultiple11/docker-compose.yml";
   private static final String BPM_MODEL_11_PARALLEL_FILENAME =
-      "src/test/resources/data/ParallelMultiple11/models/11ParallelStructured.bpmn";
+      "src/test/resources/data/ParallelMultiple11/models/" + BPM_MODEL_11_PARALLEL_NAME;
+  private static final String BPM_MODEL_MOCK_FILENAME =
+      "src/test/resources/data/ParallelMultiple11/models/" + BPM_MODEL_MOCK_NAME;
   private static final String GENERATED_BENCHMARK_FILENAME =
       "src/test/resources/data/ParallelMultiple11/benchflow-benchmark.jar";
   private static final String FABAN_CONFIGURATION_FILENAME =
       "src/test/resources/data/ParallelMultiple11/1/run.xml";
-
-  public static final String BPM_MODEL_11_PARALLEL_NAME = "11ParallelStructured.bpmn";
 
   public static InputStream getExperiment1TrialDefinition() throws FileNotFoundException {
     return new FileInputStream(EXPERIMENT_1_TRIAL_DEFINITION_FILENAME);
@@ -38,6 +41,10 @@ public class MinioTestData {
 
   public static InputStream get11ParallelStructuredModel() throws FileNotFoundException {
     return new FileInputStream(BPM_MODEL_11_PARALLEL_FILENAME);
+  }
+
+  public static InputStream getMockModel() throws FileNotFoundException {
+    return new FileInputStream(BPM_MODEL_MOCK_FILENAME);
   }
 
   public static InputStream getGeneratedBenchmark() throws FileNotFoundException {

--- a/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/resources/BenchFlowExperimentResourceTest.java
+++ b/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/resources/BenchFlowExperimentResourceTest.java
@@ -4,12 +4,10 @@ import static cloud.benchflow.experimentmanager.constants.BenchFlowConstants.MOD
 
 import cloud.benchflow.experimentmanager.constants.BenchFlowConstants;
 import cloud.benchflow.experimentmanager.helpers.BenchFlowData;
+import cloud.benchflow.experimentmanager.scheduler.ExperimentTaskScheduler;
 import cloud.benchflow.experimentmanager.services.external.MinioService;
 import cloud.benchflow.experimentmanager.services.internal.dao.BenchFlowExperimentModelDAO;
-import cloud.benchflow.experimentmanager.scheduler.ExperimentTaskScheduler;
-
 import javax.ws.rs.WebApplicationException;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/services/internal/dao/BenchFlowExperimentModelDAOIT.java
+++ b/benchflow-experiment-manager/application/src/test/java/cloud/benchflow/experimentmanager/services/internal/dao/BenchFlowExperimentModelDAOIT.java
@@ -6,9 +6,7 @@ import cloud.benchflow.experimentmanager.DockerComposeIT;
 import cloud.benchflow.experimentmanager.constants.BenchFlowConstants;
 import cloud.benchflow.experimentmanager.helpers.BenchFlowData;
 import cloud.benchflow.experimentmanager.models.BenchFlowExperimentModel;
-
 import com.mongodb.MongoClient;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/benchflow-experiment-manager/configuration.yml
+++ b/benchflow-experiment-manager/configuration.yml
@@ -86,3 +86,6 @@ testManager:
 experimentTaskExecutor:
   minThreads: 5
   maxThreads: 15
+
+testMode:
+  mockFaban: ${env.MOCK_FABAN!false?c}


### PR DESCRIPTION
Adds test mode to mock Faban with basic scenarios. The scenario to use is specified by changing the `test name` in the following way for each trial (the case of the letters doesn't matter):
- always successful execution - `alwaysCompleted`,  also default if the `test name` does not match any other scenario
- fail on first execution and then always success - `failFirstExecution`
- always failed execution - `alwaysFail`

Fixes issue in BenchFlowExperimentManagerApplicationIT that did not store the mock.bpmn model on Minio before running tests

Fixes https://github.com/benchflow/benchflow/issues/385