### PR TITLE
Adds Run Info Command to the Faban Client

### DIFF
--- a/benchflow-faban-client/pom.xml
+++ b/benchflow-faban-client/pom.xml
@@ -21,6 +21,7 @@
     <java.version>1.8</java.version>
     <httpclient.version>4.5.1</httpclient.version>
     <guava.version>18.0</guava.version>
+    <jsoup.version>1.10.3</jsoup.version>
     <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
     <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
     <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
@@ -44,6 +45,13 @@
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>${jsoup.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/benchflow-faban-client/pom.xml
+++ b/benchflow-faban-client/pom.xml
@@ -1,73 +1,84 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-      <groupId>cloud.benchflow</groupId>
-      <artifactId>benchflow</artifactId>
-      <version>0.1.0</version>
-    </parent>
-
-    <groupId>cloud.benchflow.faban</groupId>
-    <artifactId>client</artifactId>
+  <parent>
+    <groupId>cloud.benchflow</groupId>
+    <artifactId>benchflow</artifactId>
     <version>0.1.0</version>
-    <name>benchflow-faban-client</name>
+  </parent>
 
-    <properties>
-    	<project.name>benchflow-faban-client</project.name>
-    	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    	<java.version>1.8</java.version>
-        <httpclient.version>4.5.1</httpclient.version>
-        <guava.version>18.0</guava.version>
-    </properties>
+  <artifactId>faban-client</artifactId>
+  <version>0.1.0</version>
+  <name>benchflow-faban-client</name>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpclient.version}</version>
-        </dependency>
+  <properties>
+    <project.name>benchflow-faban-client</project.name>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+    <httpclient.version>4.5.1</httpclient.version>
+    <guava.version>18.0</guava.version>
+    <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
+    <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
+    <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
+  </properties>
 
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpmime</artifactId>
-            <version>${httpclient.version}</version>
-        </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
 
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-        </dependency>
-    </dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
-                <configuration>
-                	<finalName>${project.name}</finalName>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
+        <configuration>
+          <finalName>${project.name}</finalName>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <configuration>
+          <skipTests>false</skipTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
@@ -78,7 +78,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Deploy a Faban benchmark, handling the result of the deployment with an handler.
+   * Deploy a Faban benchmark, handling the result of the deployment with a handler.
    *
    * @param jarFile the benchmark to be deployed on the faban harness
    * @param driverName the name of the driver
@@ -93,7 +93,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Deploy a Faban benchmark, handling the result of the deployment with an handler.
+   * Deploy a Faban benchmark, handling the result of the deployment with a handler.
    *
    * @param jarFile the benchmark to be deployed on the faban harness
    * @param driverName the name of the driver
@@ -107,7 +107,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Deploy a Faban benchmark, handling the result of the deployment with an handler.
+   * Deploy a Faban benchmark, handling the result of the deployment with a handler.
    *
    * @param jarFile the benchmark to be deployed on the faban harness
    * @param handler a function that receives a {@link DeployStatus} and returns a {@code <T>}
@@ -122,7 +122,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
 
   /**
-   * Deploy a Faban benchmark, handling the result of the deployment with an handler.
+   * Deploy a Faban benchmark, handling the result of the deployment with a handler.
    *
    * @param jarFile the benchmark to be deployed on the faban harness
    * @param handler a consumer that receives a {@link DeployStatus}
@@ -158,7 +158,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Get the status of a Faban benchmark, handling the result with an handler.
+   * Get the status of a Faban benchmark, handling the result with a handler.
    *
    * @param runId a run id
    * @param handler a callback function
@@ -174,7 +174,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Get the status of a Faban benchmark, handling the result with an handler.
+   * Get the status of a Faban benchmark, handling the result with a handler.
    *
    * @param runId a run id
    * @param handler a callback function
@@ -210,7 +210,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Get the Run Info of a Faban benchmark, handling the result with an handler.
+   * Get the Run Info of a Faban benchmark, handling the result with a handler.
    *
    * @param runId a run id
    * @param handler a callback function
@@ -226,7 +226,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Get the Run Info of a Faban benchmark, handling the result with an handler.
+   * Get the Run Info of a Faban benchmark, handling the result with a handler.
    *
    * @param runId a run id
    * @param handler a callback function
@@ -293,7 +293,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Submit a Faban benchmark, handling the result with an handler.
+   * Submit a Faban benchmark, handling the result with a handler.
    *
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
@@ -311,7 +311,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Submit a Faban benchmark, handling the result with an handler.
+   * Submit a Faban benchmark, handling the result with a handler.
    *
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
@@ -328,7 +328,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Submit a Faban benchmark, handling the result with an handler.
+   * Submit a Faban benchmark, handling the result with a handler.
    *
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
@@ -347,7 +347,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Submit a Faban benchmark, handling the result with an handler.
+   * Submit a Faban benchmark, handling the result with a handler.
    *
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
@@ -385,7 +385,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Kill a running Faban benchmark, handling the result with an handler.
+   * Kill a running Faban benchmark, handling the result with a handler.
    *
    * @param runId a run id
    * @param handler a callback function {@link R} -> {@link T}
@@ -400,7 +400,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Kill a running Faban benchmark, handling the result with an handler.
+   * Kill a running Faban benchmark, handling the result with a handler.
    *
    * @param runId a run id
    * @param handler a callback consumer {@link R} -> void
@@ -431,7 +431,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Return the list of pending benchmarks, handling the result with an handler.
+   * Return the list of pending benchmarks, handling the result with a handler.
    *
    * @param handler a callback function {@link R} -> {@link T}
    * @param <R> a subclass of {@link RunStatus}
@@ -443,7 +443,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Return the list of pending benchmarks, handling the result with an handler.
+   * Return the list of pending benchmarks, handling the result with a handler.
    *
    * @param handler a callback consumer {@link R} -> void
    * @param <R> a subclass of {@link RunQueue}
@@ -476,7 +476,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Show the logs of a running benchmark, handling the result with an handler.
+   * Show the logs of a running benchmark, handling the result with a handler.
    *
    * @param runId the run id for the run
    * @param handler a callback function
@@ -490,7 +490,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
   }
 
   /**
-   * Show the logs of a running benchmark, handling the result with an handler.
+   * Show the logs of a running benchmark, handling the result with a handler.
    *
    * @param runId the run id for the run
    * @param handler a callback function

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/FabanClient.java
@@ -23,7 +23,6 @@ import cloud.benchflow.faban.client.responses.RunId;
 import cloud.benchflow.faban.client.responses.RunLogStream;
 import cloud.benchflow.faban.client.responses.RunQueue;
 import cloud.benchflow.faban.client.responses.RunStatus;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -34,7 +33,7 @@ import java.util.function.Function;
 
 /**
  * The faban client implementation.
- * 
+ *
  * @author Simone D'Avico (simonedavico@gmail.com)
  */
 @SuppressWarnings("unused")
@@ -48,6 +47,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Deploy a Faban benchmark.
+   *
    * @param jarFile the benchmark to be deployed on the faban harness
    * @return a response enclosing the status of the operation
    */
@@ -76,6 +76,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Deploy a Faban benchmark, handling the result of the deployment with an handler.
+   *
    * @param jarFile the benchmark to be deployed on the faban harness
    * @param driverName the name of the driver
    * @param handler a callback function
@@ -90,6 +91,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Deploy a Faban benchmark, handling the result of the deployment with an handler.
+   *
    * @param jarFile the benchmark to be deployed on the faban harness
    * @param driverName the name of the driver
    * @param handler a callback function
@@ -103,6 +105,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Deploy a Faban benchmark, handling the result of the deployment with an handler.
+   *
    * @param jarFile the benchmark to be deployed on the faban harness
    * @param handler a function that receives a {@link DeployStatus} and returns a {@code <T>}
    * @param <R> the type of the handler input (has to extend {@link DeployStatus})
@@ -117,6 +120,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Deploy a Faban benchmark, handling the result of the deployment with an handler.
+   *
    * @param jarFile the benchmark to be deployed on the faban harness
    * @param handler a consumer that receives a {@link DeployStatus}
    * @param <R> the type of the handler input (has to extend {@link DeployStatus})
@@ -129,6 +133,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Get the status of a Faban benchmark.
+   *
    * @param runId a run id
    * @return a response enclosing the status of the operation
    * @throws FabanClientException when there is an error interacting with faban
@@ -151,6 +156,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Get the status of a Faban benchmark, handling the result with an handler.
+   *
    * @param runId a run id
    * @param handler a callback function
    * @param <R> The input to the {@param handler} function, a run status
@@ -166,6 +172,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Get the status of a Faban benchmark, handling the result with an handler.
+   *
    * @param runId a run id
    * @param handler a callback function
    * @param <R> The input to the {@param handler} consumer, a run status
@@ -178,6 +185,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Submit a Faban benchmark.
+   *
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
    * @param configFile a config xml file for the run
@@ -203,6 +211,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Submit a Faban benchmark.
+   *
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
    * @param configFile a config xml file for the run
@@ -230,6 +239,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Submit a Faban benchmark, handling the result with an handler.
+   *
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
    * @param configFile a config xml file for the run
@@ -247,6 +257,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Submit a Faban benchmark, handling the result with an handler.
+   *
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
    * @param configFile a config xml file for the run
@@ -263,6 +274,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Submit a Faban benchmark, handling the result with an handler.
+   *
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
    * @param configFile a config xml file for the run
@@ -281,6 +293,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Submit a Faban benchmark, handling the result with an handler.
+   *
    * @param benchmarkName benchmark shortname
    * @param profile a profile name
    * @param configFile a config xml file
@@ -297,6 +310,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Kill a running Faban benchmark.
+   *
    * @param runId a run id
    * @return status of the kill operation
    * @throws RunIdNotFoundException when the run id is not found
@@ -317,6 +331,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Kill a running Faban benchmark, handling the result with an handler.
+   *
    * @param runId a run id
    * @param handler a callback function {@link R} -> {@link T}
    * @param <R> a subclass of {@link RunStatus}
@@ -331,6 +346,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Kill a running Faban benchmark, handling the result with an handler.
+   *
    * @param runId a run id
    * @param handler a callback consumer {@link R} -> void
    * @param <R> a subclass of {@link RunStatus}
@@ -343,6 +359,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Return the list of pending benchmarks.
+   *
    * @return a queue of pending run ids
    */
   public RunQueue pending() throws FabanClientException {
@@ -360,6 +377,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Return the list of pending benchmarks, handling the result with an handler.
+   *
    * @param handler a callback function {@link R} -> {@link T}
    * @param <R> a subclass of {@link RunStatus}
    * @param <T> return type of {@param handler}
@@ -371,6 +389,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Return the list of pending benchmarks, handling the result with an handler.
+   *
    * @param handler a callback consumer {@link R} -> void
    * @param <R> a subclass of {@link RunQueue}
    */
@@ -380,6 +399,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Show the logs of a running benchmark.
+   *
    * @param runId the run id for the run
    * @return a LogStream
    * @throws FabanClientException when there is an error interacting with faban
@@ -402,6 +422,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Show the logs of a running benchmark, handling the result with an handler.
+   *
    * @param runId the run id for the run
    * @param handler a callback function
    * @return a LogStream
@@ -415,6 +436,7 @@ public class FabanClient extends Configurable<FabanClientConfig> {
 
   /**
    * Show the logs of a running benchmark, handling the result with an handler.
+   *
    * @param runId the run id for the run
    * @param handler a callback function
    * @throws FabanClientException when there is an error interacting with faban

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/Command.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/Command.java
@@ -6,7 +6,7 @@ import cloud.benchflow.faban.client.responses.Response;
 
 /**
  * Interface for a generic command.
- * 
+ *
  * @author Simone D'Avico (simonedavico@gmail.com)
  */
 public interface Command<T extends Response> {

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/DeployCommand.java
@@ -5,12 +5,10 @@ import cloud.benchflow.faban.client.configurations.DeployConfig;
 import cloud.benchflow.faban.client.configurations.FabanClientConfig;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.responses.DeployStatus;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpPost;
@@ -30,6 +28,7 @@ public class DeployCommand extends Configurable<DeployConfig> implements Command
 
   /**
    * Deploy a Faban benchmark.
+   *
    * @param fabanConfig the harness configuration
    * @return a response containing the status of the operation
    * @throws IOException when there are issues in reading the benchmark file

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
@@ -9,13 +9,11 @@ import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
 import cloud.benchflow.faban.client.responses.RunId;
 import cloud.benchflow.faban.client.responses.RunStatus;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.ResponseHandler;

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/KillCommand.java
@@ -2,7 +2,7 @@ package cloud.benchflow.faban.client.commands;
 
 import cloud.benchflow.faban.client.configurations.Configurable;
 import cloud.benchflow.faban.client.configurations.FabanClientConfig;
-import cloud.benchflow.faban.client.configurations.StatusConfig;
+import cloud.benchflow.faban.client.configurations.RunConfig;
 import cloud.benchflow.faban.client.exceptions.EmptyHarnessResponseException;
 import cloud.benchflow.faban.client.exceptions.FabanClientException;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
@@ -29,7 +29,7 @@ import org.apache.http.message.BasicNameValuePair;
 /**
  * @author Simone D'Avico (simonedavico@gmail.com) - Created on 29/10/15.
  */
-public class KillCommand extends Configurable<StatusConfig> implements Command<RunStatus> {
+public class KillCommand extends Configurable<RunConfig> implements Command<RunStatus> {
 
   private static String KILL_URL = "/kill";
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/PendingCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/PendingCommand.java
@@ -6,14 +6,12 @@ import cloud.benchflow.faban.client.exceptions.EmptyHarnessResponseException;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.responses.RunId;
 import cloud.benchflow.faban.client.responses.RunQueue;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/RunInfoCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/RunInfoCommand.java
@@ -1,0 +1,73 @@
+package cloud.benchflow.faban.client.commands;
+
+import cloud.benchflow.faban.client.configurations.Configurable;
+import cloud.benchflow.faban.client.configurations.FabanClientConfig;
+import cloud.benchflow.faban.client.configurations.RunConfig;
+import cloud.benchflow.faban.client.exceptions.FabanClientException;
+import cloud.benchflow.faban.client.exceptions.MalformedURIException;
+import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
+import cloud.benchflow.faban.client.responses.RunId;
+import cloud.benchflow.faban.client.responses.RunInfo;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.jsoup.Jsoup;
+
+/**
+ * @author vincenzoferme
+ */
+public class RunInfoCommand extends Configurable<RunConfig> implements Command<RunInfo> {
+
+  private static String RUNINFO_PATH = "/results/get_run_info";
+  private static String RUNINFO_RUNID_PAR = "runId";
+
+  public RunInfo exec(FabanClientConfig fabanConfig) throws IOException, RunIdNotFoundException {
+    return runInfo(fabanConfig);
+  }
+
+  private RunInfo runInfo(FabanClientConfig fabanConfig)
+      throws IOException, RunIdNotFoundException {
+
+    RunId runId = config.getRunId();
+
+    ResponseHandler<RunInfo> sh =
+        resp -> new RunInfo(Jsoup.parse(new BasicResponseHandler().handleEntity(resp.getEntity())), runId);
+
+    try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+
+      URI statusURL =
+          new URIBuilder(fabanConfig.getControllerURL() + RUNINFO_PATH).addParameter(RUNINFO_RUNID_PAR, runId.toString()).build();
+
+      HttpGet get = new HttpGet(statusURL);
+
+      CloseableHttpResponse resp = httpclient.execute(get);
+
+      int status = resp.getStatusLine().getStatusCode();
+      if (status == HttpStatus.SC_NOT_FOUND) {
+        throw new RunIdNotFoundException();
+      } else if (status == HttpStatus.SC_BAD_REQUEST) {
+        throw new FabanClientException("Illegal runInfo request");
+      }
+
+      //TODO: check that the call to .handleEntity(..) actually returns the expected string
+      RunInfo runInfo = sh.handleResponse(resp);
+
+      return runInfo;
+
+    } catch (URISyntaxException e) {
+      throw new MalformedURIException(
+          "Attempted to check runInfo from malformed URI: " + e.getInput(), e);
+    }
+
+  }
+
+
+}

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/ShowLogsCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/ShowLogsCommand.java
@@ -7,14 +7,12 @@ import cloud.benchflow.faban.client.exceptions.EmptyHarnessResponseException;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
 import cloud.benchflow.faban.client.responses.RunLogStream;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/StatusCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/StatusCommand.java
@@ -2,7 +2,7 @@ package cloud.benchflow.faban.client.commands;
 
 import cloud.benchflow.faban.client.configurations.Configurable;
 import cloud.benchflow.faban.client.configurations.FabanClientConfig;
-import cloud.benchflow.faban.client.configurations.StatusConfig;
+import cloud.benchflow.faban.client.configurations.RunConfig;
 import cloud.benchflow.faban.client.exceptions.FabanClientException;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
@@ -23,7 +23,7 @@ import org.apache.http.impl.client.HttpClients;
 /**
  * @author Simone D'Avico (simonedavico@gmail.com) - Created on 28/10/15.
  */
-public class StatusCommand extends Configurable<StatusConfig> implements Command<RunStatus> {
+public class StatusCommand extends Configurable<RunConfig> implements Command<RunStatus> {
 
   private static String STATUS_PATH = "/status";
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/StatusCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/StatusCommand.java
@@ -8,11 +8,9 @@ import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
 import cloud.benchflow.faban.client.responses.RunId;
 import cloud.benchflow.faban.client.responses.RunStatus;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.apache.http.HttpStatus;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.CloseableHttpResponse;

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/commands/SubmitCommand.java
@@ -7,14 +7,11 @@ import cloud.benchflow.faban.client.exceptions.BenchmarkNameNotFoundException;
 import cloud.benchflow.faban.client.exceptions.EmptyHarnessResponseException;
 import cloud.benchflow.faban.client.exceptions.MalformedURIException;
 import cloud.benchflow.faban.client.responses.RunId;
-
 import com.google.common.io.ByteStreams;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.ResponseHandler;
@@ -41,6 +38,7 @@ public class SubmitCommand extends Configurable<SubmitConfig> implements Command
 
   /**
    * Run a Faban benchmark.
+   *
    * @param fabanConfig the harness configuration
    * @return a response containing the status of the operation
    * @throws IOException when there are issues in reading the benchmark file
@@ -48,7 +46,6 @@ public class SubmitCommand extends Configurable<SubmitConfig> implements Command
    */
   public RunId submit(FabanClientConfig fabanConfig)
       throws IOException, BenchmarkNameNotFoundException {
-
 
     String benchmarkName = config.getBenchmarkName();
     String profile = config.getProfile();

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/Config.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/Config.java
@@ -4,4 +4,5 @@ package cloud.benchflow.faban.client.configurations;
  * @author Simone D'Avico (simonedavico@gmail.com) - Created on 26/10/15.
  */
 public interface Config {
+
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/Configurable.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/Configurable.java
@@ -2,7 +2,7 @@ package cloud.benchflow.faban.client.configurations;
 
 /**
  * An abstract class representing a configurable object.
- * 
+ *
  * @author Simone D'Avico (simonedavico@gmail.com) - Created on 26/10/15.
  */
 @SuppressWarnings("unchecked")

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/DeployConfig.java
@@ -4,7 +4,7 @@ import java.io.File;
 
 /**
  * Created by simonedavico on 26/10/15.
- * 
+ * <p>
  * <p>Configuration class for the deploy command
  */
 public class DeployConfig implements Config {
@@ -16,6 +16,7 @@ public class DeployConfig implements Config {
 
   /**
    * Construct a DeployConfig from the benchmark file and a name for the driver.
+   *
    * @param jarFile the benchmark file
    * @param driverName the driver name
    */
@@ -26,6 +27,7 @@ public class DeployConfig implements Config {
   /**
    * Construct a DeployConfig from the benchmark file and a name for the driver,
    * clearing the previous configuration for the benchmark.
+   *
    * @param jarFile the benchmark file
    * @param driverName the driver name
    * @param clearConfig true for clearing the previous configuration for the benchmark

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfig.java
@@ -4,6 +4,7 @@ import java.net.URI;
 
 /**
  * Created by simonedavico on 26/10/15.
+ * @author vincenzoferme
  */
 public interface FabanClientConfig extends Config {
 
@@ -12,4 +13,6 @@ public interface FabanClientConfig extends Config {
   String getPassword();
 
   URI getMasterURL();
+
+  URI getControllerURL();
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfigImpl.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfigImpl.java
@@ -1,19 +1,22 @@
 package cloud.benchflow.faban.client.configurations;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * A configuration class for the faban client.
  * The user can configure username and password,
  * or username, password and masterURL.
  *
- * @author Simone D'Avico (simonedavico@gmail.com)
+ * @author Simone D'Avico (simonedavico@gmail.com)\
+ * @author vincenzoferme
  */
 public class FabanClientConfigImpl implements FabanClientConfig {
 
   private final String user;
   private final String password;
   private final URI masterURL;
+  private final URI controllerURL;
 
   /**
    * Creates a FabanClientConfigImpl on the default url.
@@ -36,6 +39,19 @@ public class FabanClientConfigImpl implements FabanClientConfig {
     this.user = user;
     this.password = password;
     this.masterURL = masterURL;
+
+    URI controllerURL = null;
+
+    try {
+      controllerURL = new URI(masterURL + "/controller");
+    } catch (URISyntaxException e) {
+      System.err.println("There was a problem initializing the default "
+          + "faban client configuration. See the stack" + "trace for more informations.");
+      e.printStackTrace();
+    }
+
+    this.controllerURL = controllerURL;
+
   }
 
 
@@ -49,5 +65,9 @@ public class FabanClientConfigImpl implements FabanClientConfig {
 
   public URI getMasterURL() {
     return masterURL;
+  }
+
+  public URI getControllerURL() {
+    return controllerURL;
   }
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfigImpl.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientConfigImpl.java
@@ -17,6 +17,7 @@ public class FabanClientConfigImpl implements FabanClientConfig {
 
   /**
    * Creates a FabanClientConfigImpl on the default url.
+   *
    * @param user Faban harness username
    * @param password Faban harness password
    */
@@ -26,6 +27,7 @@ public class FabanClientConfigImpl implements FabanClientConfig {
 
   /**
    * Creates a FabanClientConfigImpl on a custom url.
+   *
    * @param user Faban harness username
    * @param password Faban harness password
    * @param masterURL Faban harness url

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientDefaultConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientDefaultConfig.java
@@ -7,6 +7,8 @@ import java.net.URISyntaxException;
  * Created by simonedavico on 26/10/15.
  * <p>
  * <p>Default configuration for the Faban client.
+ *
+ * @author vincenzoferme
  */
 public class FabanClientDefaultConfig implements FabanClientConfig {
 
@@ -20,7 +22,7 @@ public class FabanClientDefaultConfig implements FabanClientConfig {
     FabanClientConfigImpl defConf = null;
     try {
       defConf =
-          new FabanClientConfigImpl("deployer", "adminadmin", new URI("http://localhost:9980/"));
+          new FabanClientConfigImpl("deployer", "adminadmin", new URI("http://localhost:9980"));
     } catch (URISyntaxException e) {
       System.err.println("There was a problem initializing the default "
           + "faban client configuration. See the stack" + "trace for more informations.");
@@ -40,5 +42,7 @@ public class FabanClientDefaultConfig implements FabanClientConfig {
   public URI getMasterURL() {
     return defaultConfig.getMasterURL();
   }
+
+  public URI getControllerURL() { return defaultConfig.getControllerURL(); }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientDefaultConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/FabanClientDefaultConfig.java
@@ -5,7 +5,7 @@ import java.net.URISyntaxException;
 
 /**
  * Created by simonedavico on 26/10/15.
- *
+ * <p>
  * <p>Default configuration for the Faban client.
  */
 public class FabanClientDefaultConfig implements FabanClientConfig {

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/RunConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/RunConfig.java
@@ -4,12 +4,13 @@ import cloud.benchflow.faban.client.responses.RunId;
 
 /**
  * @author Simone D'Avico (simonedavico@gmail.com) - Created on 28/10/15.
+ * @author vincenzoferme
  */
-public class StatusConfig implements Config {
+public class RunConfig implements Config {
 
   private RunId runId;
 
-  public StatusConfig(RunId runId) {
+  public RunConfig(RunId runId) {
     this.runId = runId;
   }
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/SubmitConfig.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/configurations/SubmitConfig.java
@@ -13,6 +13,7 @@ public class SubmitConfig implements Config {
 
   /**
    * Construct a SubmitConfig.
+   *
    * @param benchmarkName the benchmark name
    * @param profile the benchmark profile
    * @param configFile the configuration file for this run

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/BenchmarkNameNotFoundException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/BenchmarkNameNotFoundException.java
@@ -6,6 +6,7 @@ package cloud.benchflow.faban.client.exceptions;
  *         Created on 29/10/15.
  */
 public class BenchmarkNameNotFoundException extends FabanClientException {
+
   public BenchmarkNameNotFoundException(String message) {
     super(message);
   }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/ConfigFileNotFoundException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/ConfigFileNotFoundException.java
@@ -4,6 +4,7 @@ package cloud.benchflow.faban.client.exceptions;
  * @author Simone D'Avico (simonedavico@gmail.com) - Created on 28/10/15.
  */
 public class ConfigFileNotFoundException extends Exception {
+
   public ConfigFileNotFoundException(String message) {
     super(message);
   }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/DeployException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/DeployException.java
@@ -3,7 +3,6 @@ package cloud.benchflow.faban.client.exceptions;
 
 /**
  * Created by simonedavico on 28/10/15.
- *
  */
 public class DeployException extends FabanClientException {
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/IllegalRunIdException.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/exceptions/IllegalRunIdException.java
@@ -4,6 +4,7 @@ package cloud.benchflow.faban.client.exceptions;
  * Created by simonedavico on 28/10/15.
  */
 public class IllegalRunIdException extends FabanClientException {
+
   public IllegalRunIdException(String s) {
     super(s);
   }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/DeployStatus.java
@@ -1,24 +1,20 @@
 package cloud.benchflow.faban.client.responses;
 
 import cloud.benchflow.faban.client.exceptions.DeployException;
-
 import org.apache.http.HttpStatus;
 
 
 /**
- *
  * @author Simone D'Avico (simonedavico@gmail.com)
  */
 public class DeployStatus implements Response {
 
-  public enum Code {
-    CONFLICT, NOT_ACCEPTABLE, CREATED
-  }
-
   private Code code;
+
 
   /**
    * Construct a Deploy Status response.
+   *
    * @param statusCode the deploy status code
    */
   public DeployStatus(int statusCode) {
@@ -40,6 +36,10 @@ public class DeployStatus implements Response {
 
   public Code getCode() {
     return this.code;
+  }
+
+  public enum Code {
+    CONFLICT, NOT_ACCEPTABLE, CREATED
   }
 
 }

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/Response.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/Response.java
@@ -4,7 +4,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- *
  * @author Simone D'Avico (simonedavico@gmail.com)
  */
 @SuppressWarnings("unchecked")

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunId.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunId.java
@@ -3,7 +3,6 @@ package cloud.benchflow.faban.client.responses;
 import cloud.benchflow.faban.client.exceptions.IllegalRunIdException;
 
 /**
- *
  * @author Simone D'Avico (simonedavico@gmail.com)
  */
 public class RunId implements Response {
@@ -13,6 +12,7 @@ public class RunId implements Response {
 
   /**
    * Contruct a run id response.
+   *
    * @param name the name of the benchmark
    * @param queueId the id of the benchmark in the queue
    */
@@ -23,6 +23,7 @@ public class RunId implements Response {
 
   /**
    * Contruct a run id response.
+   *
    * @param runId the run id of the benchmark
    */
   public RunId(String runId) {

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunInfo.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunInfo.java
@@ -15,7 +15,7 @@ import org.jsoup.select.Elements;
  */
 public class RunInfo implements Response {
 
-  //Most of the types could be N/A, that is why most of them are threatened as String
+  //Most of the types could be N/A, that is why most of them are treated as String
   //See: https://github.com/akara/faban/blob/master/harness/src/com/sun/faban/harness/webclient/Results.java#L382
   private String description;
   private Result result;

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunInfo.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunInfo.java
@@ -76,6 +76,12 @@ public class RunInfo implements Response {
     Elements result = runInfo.select("td#Result");
 
     switch (result.text()) {
+      case "PASSED":
+        this.result = Result.PASSED;
+        break;
+      case "FAILED":
+        this.result = Result.FAILED;
+        break;
       case "N/A":
         this.result = Result.NA;
         break;
@@ -93,9 +99,13 @@ public class RunInfo implements Response {
 
   /**
    * Possible result codes.
+   *
+   * Sources:
+   *  - All possible values assigned to the result variable in: https://github.com/akara/faban/blob/master/harness/src/com/sun/faban/harness/webclient/RunResult.java
+   *  - All possible values assigned to the runInfo[2] variable in: https://github.com/akara/faban/blob/master/harness/src/com/sun/faban/harness/webclient/Results.java
    */
   public enum Result {
-    NA, NOT_AVAILABLE, UNKNOWN
+    PASSED, FAILED, NA, NOT_AVAILABLE, UNKNOWN
   }
 
   @Override

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunInfo.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunInfo.java
@@ -8,8 +8,6 @@ import java.util.Date;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 
-;
-
 /**
  * @author vincenzoferme
  */
@@ -22,7 +20,7 @@ public class RunInfo implements Response {
   private String scale;
   private String metric;
   private RunStatus status;
-  private Date date_time;
+  private Date dateTime;
   private String submitter;
   private String tags;
 
@@ -70,7 +68,7 @@ public class RunInfo implements Response {
     //See https://github.com/akara/faban/blob/master/harness/src/com/sun/faban/harness/webclient/Results.java#L412
     if(!date_time.text().equals("N/A")) {
       try {
-        this.date_time = df.parse(date_time.text());
+        this.dateTime = df.parse(date_time.text());
       } catch (ParseException e) {
 
         //TODO: we need a logger in the faban client as well
@@ -79,11 +77,11 @@ public class RunInfo implements Response {
                 + runId);
         e.printStackTrace();
         //We default to the current date, because it should anyway be very close to the retrieved one
-        this.date_time = new Date();
+        this.dateTime = new Date();
       }
     } else {
       //We default to the current date, because it should anyway be very close to the retrieved one
-      this.date_time = new Date();
+      this.dateTime = new Date();
     }
   }
 
@@ -131,7 +129,7 @@ public class RunInfo implements Response {
         ", scale=" + scale +
         ", metric='" + metric + '\'' +
         ", status=" + status.getStatus() +
-        ", date_time=" + date_time +
+        ", dateTime=" + dateTime +
         ", submitter='" + submitter + '\'' +
         ", tags='" + tags + '\'' +
         '}';
@@ -157,7 +155,7 @@ public class RunInfo implements Response {
     return status;
   }
 
-  public Date getDate_time() { return date_time; }
+  public Date getDateTime() { return dateTime; }
 
   public String getSubmitter() {
     return submitter;

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunInfo.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunInfo.java
@@ -1,0 +1,146 @@
+package cloud.benchflow.faban.client.responses;
+
+import cloud.benchflow.faban.client.exceptions.IllegalRunStatusException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+
+;
+
+/**
+ * @author vincenzoferme
+ */
+public class RunInfo implements Response {
+
+  private String description;
+  private Result result;
+  private Integer scale;
+  private String metric;
+  private RunStatus status;
+  private Date date_time;
+  private String submitter;
+  private String tags;
+
+  /**
+   * Construct a Run Info
+   *
+   * @param runInfo the run info
+   * @param runId the run id
+   */
+  public RunInfo(Document runInfo, RunId runId) {
+
+    Elements description = runInfo.select("td#Description");
+    this.description = description.text();
+
+    handleResult(runInfo, runId);
+
+    Elements scale = runInfo.select("td#Scale");
+    this.scale = Integer.getInteger(scale.text());
+
+    Elements metric = runInfo.select("td#Metric");
+    this.metric = metric.text();
+
+    Elements status = runInfo.select("td#Status");
+    this.status = new RunStatus(status.text(),runId);
+
+    Elements submitter = runInfo.select("td#Submitter");
+    this.submitter = submitter.text();
+
+    Elements tags = runInfo.select("td#Tags");
+    this.tags = tags.text();
+
+    //TODO - improve when this is supported by jsoup: https://stackoverflow.com/questions/5153986/css-selector-to-select-an-id-with-a-slash-in-the-id-name
+    runInfo.html(runInfo.html().replace("id=\"Date/Time\"","id=\"DateTime\""));
+    Elements date_time = runInfo.select("td#DateTime");
+    //See http://developer.android.com/reference/java/text/SimpleDateFormat.html
+    DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ssZ");
+
+    try {
+      this.date_time = df.parse(date_time.text());
+    } catch (ParseException e) {
+
+      //TODO: we need a logger in the faban client as well
+      System.err.println(
+          "Something went wrong while converting the date " + date_time.text() + " for run " + runId);
+      e.printStackTrace();
+      //We default to the current date, because it should anyway be very close to the retrieved one
+      this.date_time = new Date();
+    }
+
+  }
+
+  private void handleResult(Document runInfo, RunId runId) {
+    Elements result = runInfo.select("td#Result");
+
+    switch (result.text()) {
+      case "N/A":
+        this.result = Result.NA;
+        break;
+      case "NOT_AVAILABLE":
+        this.result = Result.NOT_AVAILABLE;
+        break;
+      case "UNKNOWN":
+        this.result = Result.UNKNOWN;
+        break;
+      default:
+        throw new IllegalRunStatusException(
+            "RunId " + runId + "returned illegal run info result " + result.text());
+    }
+  }
+
+  /**
+   * Possible result codes.
+   */
+  public enum Result {
+    NA, NOT_AVAILABLE, UNKNOWN
+  }
+
+  @Override
+  public String toString() {
+    return "RunInfo{" +
+        "description='" + description + '\'' +
+        ", result=" + result +
+        ", scale=" + scale +
+        ", metric='" + metric + '\'' +
+        ", status=" + status.getStatus() +
+        ", date_time=" + date_time +
+        ", submitter='" + submitter + '\'' +
+        ", tags='" + tags + '\'' +
+        '}';
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public Result getResult() {
+    return result;
+  }
+
+  public Integer getScale() {
+    return scale;
+  }
+
+  public String getMetric() {
+    return metric;
+  }
+
+  public RunStatus getStatus() {
+    return status;
+  }
+
+  public Date getDate_time() { return date_time; }
+
+  public String getSubmitter() {
+    return submitter;
+  }
+
+  public String getTags() {
+    return tags;
+  }
+
+
+}

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
@@ -9,15 +9,10 @@ public class RunStatus implements Response {
 
   private Code status;
 
-  /**
-   * Possible run statuses.
-   */
-  public enum Code {
-    QUEUED, RECEIVED, STARTED, COMPLETED, FAILED, KILLED, KILLING, DENIED
-  }
 
   /**
    * Construct a run status.
+   *
    * @param statusCode the status code
    * @param runId the run id
    */
@@ -55,6 +50,13 @@ public class RunStatus implements Response {
 
   public Code getStatus() {
     return this.status;
+  }
+
+  /**
+   * Possible run statuses.
+   */
+  public enum Code {
+    QUEUED, RECEIVED, STARTED, COMPLETED, FAILED, KILLED, KILLING, DENIED
   }
 
 

--- a/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
+++ b/benchflow-faban-client/src/main/java/cloud/benchflow/faban/client/responses/RunStatus.java
@@ -7,7 +7,7 @@ import cloud.benchflow.faban.client.exceptions.IllegalRunStatusException;
  */
 public class RunStatus implements Response {
 
-  private Code status;
+  private StatusCode status;
 
 
   /**
@@ -19,28 +19,28 @@ public class RunStatus implements Response {
   public RunStatus(String statusCode, RunId runId) {
     switch (statusCode.replace("\n", "")) {
       case "QUEUED":
-        this.status = Code.QUEUED;
+        this.status = StatusCode.QUEUED;
         break;
       case "RECEIVED":
-        this.status = Code.RECEIVED;
+        this.status = StatusCode.RECEIVED;
         break;
       case "STARTED":
-        this.status = Code.STARTED;
+        this.status = StatusCode.STARTED;
         break;
       case "COMPLETED":
-        this.status = Code.COMPLETED;
+        this.status = StatusCode.COMPLETED;
         break;
       case "FAILED":
-        this.status = Code.FAILED;
+        this.status = StatusCode.FAILED;
         break;
       case "KILLED":
-        this.status = Code.KILLED;
+        this.status = StatusCode.KILLED;
         break;
       case "KILLING":
-        this.status = Code.KILLING;
+        this.status = StatusCode.KILLING;
         break;
       case "DENIED":
-        this.status = Code.DENIED;
+        this.status = StatusCode.DENIED;
         break;
       default:
         throw new IllegalRunStatusException(
@@ -48,14 +48,14 @@ public class RunStatus implements Response {
     }
   }
 
-  public Code getStatus() {
+  public StatusCode getStatus() {
     return this.status;
   }
 
   /**
    * Possible run statuses.
    */
-  public enum Code {
+  public enum StatusCode {
     QUEUED, RECEIVED, STARTED, COMPLETED, FAILED, KILLED, KILLING, DENIED
   }
 

--- a/benchflow-faban-client/src/test/java/cloud/benchflow/faban/test/client/Main.java
+++ b/benchflow-faban-client/src/test/java/cloud/benchflow/faban/test/client/Main.java
@@ -7,7 +7,6 @@ import cloud.benchflow.faban.client.exceptions.ConfigFileNotFoundException;
 import cloud.benchflow.faban.client.exceptions.JarFileNotFoundException;
 import cloud.benchflow.faban.client.exceptions.RunIdNotFoundException;
 import cloud.benchflow.faban.client.responses.DeployStatus;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/benchflow-faban-client/src/test/resources/run.1.1.1.xml
+++ b/benchflow-faban-client/src/test/resources/run.1.1.1.xml
@@ -4,7 +4,10 @@
     <fh:javaHome>/usr/lib/jvm/java7</fh:javaHome>
     <fh:jvmOptions>-Xmx2048m -Xms124m -XX:+DisableExplicitGC</fh:jvmOptions>
   </jvmConfig>
-  <fa:runConfig definition="cloud.benchflow.experiment.drivers.WfMSStartDriver" xmlns="http://faban.sunsource.net/ns/fabandriver" xmlns:fh="http://faban.sunsource.net/ns/fabanharness" xmlns:fa="http://faban.sunsource.net/ns/faban">
+  <fa:runConfig xmlns:fa="http://faban.sunsource.net/ns/faban"
+    xmlns:fh="http://faban.sunsource.net/ns/fabanharness"
+    definition="cloud.benchflow.experiment.drivers.WfMSStartDriver"
+    xmlns="http://faban.sunsource.net/ns/fabandriver">
     <fh:description>First wfms test</fh:description>
     <fa:scale>2000</fa:scale>
     <fh:timeSync>false</fh:timeSync>
@@ -84,7 +87,9 @@
               <monitor name="cpu">
                 <id>benchflow.monitor.mysql.db.cpu</id>
                 <configuration>
-                  <param name="COMPLETION_QUERY">SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL</param>
+                  <param name="COMPLETION_QUERY">
+                    SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL
+                  </param>
                   <param name="COMPLETION_QUERY_VALUE">0</param>
                   <param name="COMPLETION_QUERY_METHOD">equal</param>
                 </configuration>
@@ -96,7 +101,9 @@
               <monitor name="querymysql">
                 <id>benchflow.monitor.mysql.db.querymysql</id>
                 <configuration>
-                  <param name="COMPLETION_QUERY">SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL</param>
+                  <param name="COMPLETION_QUERY">
+                    SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL
+                  </param>
                   <param name="COMPLETION_QUERY_VALUE">0</param>
                   <param name="COMPLETION_QUERY_METHOD">equal</param>
                 </configuration>

--- a/benchflow-faban-client/src/test/resources/run.1.1.2.xml
+++ b/benchflow-faban-client/src/test/resources/run.1.1.2.xml
@@ -4,7 +4,10 @@
     <fh:javaHome>/usr/lib/jvm/java7</fh:javaHome>
     <fh:jvmOptions>-Xmx2048m -Xms124m -XX:+DisableExplicitGC</fh:jvmOptions>
   </jvmConfig>
-  <fa:runConfig definition="cloud.benchflow.experiment.drivers.WfMSStartDriver" xmlns="http://faban.sunsource.net/ns/fabandriver" xmlns:fh="http://faban.sunsource.net/ns/fabanharness" xmlns:fa="http://faban.sunsource.net/ns/faban">
+  <fa:runConfig xmlns:fa="http://faban.sunsource.net/ns/faban"
+    xmlns:fh="http://faban.sunsource.net/ns/fabanharness"
+    definition="cloud.benchflow.experiment.drivers.WfMSStartDriver"
+    xmlns="http://faban.sunsource.net/ns/fabandriver">
     <fh:description>First wfms test</fh:description>
     <fa:scale>2000</fa:scale>
     <fh:timeSync>false</fh:timeSync>
@@ -84,7 +87,9 @@
               <monitor name="cpu">
                 <id>benchflow.monitor.mysql.db.cpu</id>
                 <configuration>
-                  <param name="COMPLETION_QUERY">SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL</param>
+                  <param name="COMPLETION_QUERY">
+                    SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL
+                  </param>
                   <param name="COMPLETION_QUERY_VALUE">0</param>
                   <param name="COMPLETION_QUERY_METHOD">equal</param>
                 </configuration>
@@ -96,7 +101,9 @@
               <monitor name="querymysql">
                 <id>benchflow.monitor.mysql.db.querymysql</id>
                 <configuration>
-                  <param name="COMPLETION_QUERY">SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL</param>
+                  <param name="COMPLETION_QUERY">
+                    SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL
+                  </param>
                   <param name="COMPLETION_QUERY_VALUE">0</param>
                   <param name="COMPLETION_QUERY_METHOD">equal</param>
                 </configuration>

--- a/benchflow-faban-client/src/test/resources/run.1.1.3.xml
+++ b/benchflow-faban-client/src/test/resources/run.1.1.3.xml
@@ -4,7 +4,10 @@
     <fh:javaHome>/usr/lib/jvm/java7</fh:javaHome>
     <fh:jvmOptions>-Xmx2048m -Xms124m -XX:+DisableExplicitGC</fh:jvmOptions>
   </jvmConfig>
-  <fa:runConfig definition="cloud.benchflow.experiment.drivers.WfMSStartDriver" xmlns="http://faban.sunsource.net/ns/fabandriver" xmlns:fh="http://faban.sunsource.net/ns/fabanharness" xmlns:fa="http://faban.sunsource.net/ns/faban">
+  <fa:runConfig xmlns:fa="http://faban.sunsource.net/ns/faban"
+    xmlns:fh="http://faban.sunsource.net/ns/fabanharness"
+    definition="cloud.benchflow.experiment.drivers.WfMSStartDriver"
+    xmlns="http://faban.sunsource.net/ns/fabandriver">
     <fh:description>First wfms test</fh:description>
     <fa:scale>2000</fa:scale>
     <fh:timeSync>false</fh:timeSync>
@@ -84,7 +87,9 @@
               <monitor name="cpu">
                 <id>benchflow.monitor.mysql.db.cpu</id>
                 <configuration>
-                  <param name="COMPLETION_QUERY">SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL</param>
+                  <param name="COMPLETION_QUERY">
+                    SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL
+                  </param>
                   <param name="COMPLETION_QUERY_VALUE">0</param>
                   <param name="COMPLETION_QUERY_METHOD">equal</param>
                 </configuration>
@@ -96,7 +101,9 @@
               <monitor name="querymysql">
                 <id>benchflow.monitor.mysql.db.querymysql</id>
                 <configuration>
-                  <param name="COMPLETION_QUERY">SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL</param>
+                  <param name="COMPLETION_QUERY">
+                    SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL
+                  </param>
                   <param name="COMPLETION_QUERY_VALUE">0</param>
                   <param name="COMPLETION_QUERY_METHOD">equal</param>
                 </configuration>


### PR DESCRIPTION
Related to: https://github.com/benchflow/benchflow/issues/420

Adds a command to access the [Run Info](https://github.com/akara/faban/blob/d6832a3833dd0ce0d713d7fa7f178ea24e77d605/harness/src/com/sun/faban/harness/webclient/ResultAction.java). The Run Info data are not exposed on the [CLIServlet](https://github.com/akara/faban/blob/d6832a3833dd0ce0d713d7fa7f178ea24e77d605/harness/src/com/sun/faban/harness/webclient/CLIServlet.java), and they are only available on the Faban UI. For this reason we need to access these data using a different API and parse the HTML result. 