### PR TITLE
Adds experiment termination criteria type as enum

### DIFF
--- a/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/definition/configuration/terminationcriteria/experiment/ExperimentTerminationCriteria.scala
+++ b/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/definition/configuration/terminationcriteria/experiment/ExperimentTerminationCriteria.scala
@@ -1,8 +1,11 @@
 package cloud.benchflow.dsl.definition.configuration.terminationcriteria.experiment
 
+import cloud.benchflow.dsl.definition.configuration.terminationcriteria.experiment.criteriatype.CriteriaType
+
 /**
  * @author Jesper Findahl (jesper.findahl@usi.ch)
  *         created on 11.03.17.
  */
-// TODO - adjust according to DSL specification
-case class ExperimentTerminationCriteria(criteriaType: String, number: Int)
+case class ExperimentTerminationCriteria(
+  criteriaType: CriteriaType,
+  number: Int)

--- a/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/definition/configuration/terminationcriteria/experiment/ExperimentTerminationCriteriaYamlProtocol.scala
+++ b/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/definition/configuration/terminationcriteria/experiment/ExperimentTerminationCriteriaYamlProtocol.scala
@@ -2,6 +2,8 @@ package cloud.benchflow.dsl.definition.configuration.terminationcriteria.experim
 
 import cloud.benchflow.dsl.definition.configuration.terminationcriteria.BenchFlowTestTerminationCriteriaYamlProtocol
 import cloud.benchflow.dsl.definition.configuration.terminationcriteria.BenchFlowTestTerminationCriteriaYamlProtocol.ExperimentKey
+import cloud.benchflow.dsl.definition.configuration.terminationcriteria.experiment.criteriatype.CriteriaType
+import cloud.benchflow.dsl.definition.configuration.terminationcriteria.experiment.criteriatype.CriteriaTypeYamlProtocol._
 import cloud.benchflow.dsl.definition.errorhandling.YamlErrorHandler.{ deserializationHandler, unsupportedReadOperation, unsupportedWriteOperation }
 import net.jcazevedo.moultingyaml.{ DefaultYamlProtocol, YamlFormat, YamlObject, YamlString, YamlValue, _ }
 
@@ -28,7 +30,7 @@ object ExperimentTerminationCriteriaYamlProtocol extends DefaultYamlProtocol {
       for {
 
         criteriaType <- deserializationHandler(
-          yamlObject.fields(TypeKey).convertTo[String],
+          yamlObject.fields(TypeKey).convertTo[Try[CriteriaType]].get,
           keyString(TypeKey))
 
         number <- deserializationHandler(

--- a/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/definition/configuration/terminationcriteria/experiment/criteriatype/CriteriaType.java
+++ b/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/definition/configuration/terminationcriteria/experiment/criteriatype/CriteriaType.java
@@ -1,0 +1,21 @@
+package cloud.benchflow.dsl.definition.configuration.terminationcriteria.experiment.criteriatype;
+
+/**
+  * @author Jesper Findahl (jesper.findahl@gmail.com) 
+  *         created on 2017-06-22
+  */
+public enum CriteriaType {
+  FIXED("fixed");
+//  CONFIDENCE_INTERVAL("confidence-interval")
+
+  private final String stringValue;
+
+  CriteriaType(String stringValue) {
+    this.stringValue = stringValue;
+  }
+
+  @Override
+  public String toString() {
+    return stringValue;
+  }
+}

--- a/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/definition/configuration/terminationcriteria/experiment/criteriatype/CriteriaTypeYamlProtocol.scala
+++ b/benchflow-dsl/src/main/scala/cloud/benchflow/dsl/definition/configuration/terminationcriteria/experiment/criteriatype/CriteriaTypeYamlProtocol.scala
@@ -1,0 +1,38 @@
+package cloud.benchflow.dsl.definition.configuration.terminationcriteria.experiment.criteriatype
+
+import cloud.benchflow.dsl.definition.errorhandling.YamlErrorHandler.{ unsupportedReadOperation, unsupportedWriteOperation }
+import net.jcazevedo.moultingyaml.{ DefaultYamlProtocol, YamlFormat, YamlValue, _ }
+
+import scala.util.{ Failure, Success, Try }
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com)
+ *         created on 2017-06-22
+ */
+object CriteriaTypeYamlProtocol extends DefaultYamlProtocol {
+
+  implicit object CriteriaTypeReadFormat extends YamlFormat[Try[CriteriaType]] {
+    override def read(yaml: YamlValue): Try[CriteriaType] = {
+
+      val stringValue = yaml.asInstanceOf[YamlString].value.toLowerCase
+
+      val optionCriteriaType: Option[CriteriaType] = CriteriaType.values.find(_.toString == stringValue)
+
+      optionCriteriaType match {
+        case Some(criteriaType) => Success(criteriaType)
+        case None => Failure(DeserializationException("Unexpected experiment criteria type"))
+      }
+
+    }
+
+    override def write(obj: Try[CriteriaType]): YamlValue = unsupportedWriteOperation
+  }
+
+  implicit object CriteriaTypeWriterFormat extends YamlFormat[CriteriaType] {
+
+    override def write(obj: CriteriaType): YamlValue = obj.toString.toYaml
+
+    override def read(yaml: YamlValue): CriteriaType = unsupportedReadOperation
+  }
+
+}

--- a/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/definition/configuration/terminationcriteria/experiment/ExperimentTerminationCriteriaTest.scala
+++ b/benchflow-dsl/src/test/scala/cloud/benchflow/dsl/definition/configuration/terminationcriteria/experiment/ExperimentTerminationCriteriaTest.scala
@@ -19,9 +19,25 @@ class ExperimentTerminationCriteriaTest extends JUnitSuite {
 
   @Test def fixedTerminationCriteria(): Unit = {
 
-    val experimentTerminationCriteria: Try[ExperimentTerminationCriteria] = fixedterminationCriteriaYaml.parseYaml.convertTo[Try[ExperimentTerminationCriteria]]
+    val experimentTerminationCriteria = fixedterminationCriteriaYaml.parseYaml.convertTo[Try[ExperimentTerminationCriteria]]
 
     Assert.assertTrue(experimentTerminationCriteria.isSuccess)
+
+    val experimentTerminationCriteriaYaml = experimentTerminationCriteria.get.toYaml
+
+    Assert.assertTrue(experimentTerminationCriteriaYaml.prettyPrint.contains("type: fixed"))
+
+  }
+
+  @Test def invalidTerminationCriteriaType(): Unit = {
+
+    val invalidTerminationCriteriaTypeYaml: String =
+      """type: invalid
+        |number: 5""".stripMargin
+
+    val experimentTerminationCriteria = invalidTerminationCriteriaTypeYaml.parseYaml.convertTo[Try[ExperimentTerminationCriteria]]
+
+    Assert.assertTrue(experimentTerminationCriteria.isFailure)
 
   }
 


### PR DESCRIPTION
Experiment termination criteria Type was only a `String`. With this PR it is converted into an `enum` so we can validate the type.

depends on https://github.com/benchflow/benchflow/pull/458