### PR TITLE
Saves exploration space in db

### DIFF
--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/BenchFlowTestManagerApplication.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/BenchFlowTestManagerApplication.java
@@ -126,9 +126,9 @@ public class BenchFlowTestManagerApplication
     // Typically you only create one MongoClient instance for a given MongoDB deployment
     // (e.g. standalone, replica set, or a sharded cluster) and use it across your application.
     // http://mongodb.github.io/mongo-java-driver/3.4/driver/getting-started/quick-start/
-    MongoClient mongoClient = configuration.getMongoDBFactory().build();
-    ExecutorService taskExecutor = configuration.getTaskExecutorFactory().build(environment);
-    ScheduledThreadPoolExecutor timeOutScheduledThreadPoolExecutor =
+    final MongoClient mongoClient = configuration.getMongoDBFactory().build();
+    final ExecutorService taskExecutor = configuration.getTaskExecutorFactory().build(environment);
+    final ScheduledThreadPoolExecutor timeOutScheduledThreadPoolExecutor =
         new ScheduledThreadPoolExecutor(1);
 
     testModelDAO = new BenchFlowTestModelDAO(mongoClient);

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/BenchFlowTestModel.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/BenchFlowTestModel.java
@@ -119,12 +119,12 @@ public class BenchFlowTestModel {
     return lastModified;
   }
 
-  public void setMaxRunningTime(Time maxRunningTime) {
-    this.maxRunningTime = maxRunningTime;
-  }
-
   public Time getMaxRunningTime() {
     return maxRunningTime;
+  }
+
+  public void setMaxRunningTime(Time maxRunningTime) {
+    this.maxRunningTime = maxRunningTime;
   }
 
   public BenchFlowTestState getState() {

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/ExplorationModel.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/ExplorationModel.java
@@ -4,8 +4,8 @@ import cloud.benchflow.dsl.definition.configuration.goal.goaltype.GoalType;
 import cloud.benchflow.dsl.definition.configuration.strategy.regression.RegressionStrategyType;
 import cloud.benchflow.dsl.definition.configuration.strategy.selection.SelectionStrategyType;
 import cloud.benchflow.dsl.definition.configuration.strategy.validation.ValidationStrategyType;
-import cloud.benchflow.dsl.explorationspace.ExplorationSpaceGenerator.ExplorationSpace;
-import cloud.benchflow.dsl.explorationspace.ExplorationSpaceGenerator.ExplorationSpaceDimensions;
+import cloud.benchflow.testmanager.models.explorationspace.MongoCompatibleExplorationSpace;
+import cloud.benchflow.testmanager.models.explorationspace.MongoCompatibleExplorationSpaceDimensions;
 import java.util.ArrayList;
 import java.util.List;
 import org.mongodb.morphia.annotations.Embedded;
@@ -18,8 +18,8 @@ public class ExplorationModel {
 
   private GoalType goalType;
 
-  private ExplorationSpaceDimensions explorationSpaceDimensions;
-  private ExplorationSpace explorationSpace;
+  private MongoCompatibleExplorationSpaceDimensions explorationSpaceDimensions;
+  private MongoCompatibleExplorationSpace explorationSpace;
 
   private List<Integer> executedExplorationPointIndices = new ArrayList<>();
 
@@ -38,19 +38,20 @@ public class ExplorationModel {
     this.goalType = goalType;
   }
 
-  public ExplorationSpaceDimensions getExplorationSpaceDimensions() {
+  public MongoCompatibleExplorationSpaceDimensions getExplorationSpaceDimensions() {
     return explorationSpaceDimensions;
   }
 
-  public void setExplorationSpaceDimensions(ExplorationSpaceDimensions explorationSpaceDimensions) {
+  public void setExplorationSpaceDimensions(
+      MongoCompatibleExplorationSpaceDimensions explorationSpaceDimensions) {
     this.explorationSpaceDimensions = explorationSpaceDimensions;
   }
 
-  public ExplorationSpace getExplorationSpace() {
+  public MongoCompatibleExplorationSpace getExplorationSpace() {
     return explorationSpace;
   }
 
-  public void setExplorationSpace(ExplorationSpace explorationSpace) {
+  public void setExplorationSpace(MongoCompatibleExplorationSpace explorationSpace) {
     this.explorationSpace = explorationSpace;
   }
 
@@ -101,4 +102,5 @@ public class ExplorationModel {
   public void setSingleExperiment(boolean singleExperiment) {
     this.singleExperiment = singleExperiment;
   }
+
 }

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/explorationspace/MongoCompatibleExplorationSpace.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/explorationspace/MongoCompatibleExplorationSpace.java
@@ -1,0 +1,97 @@
+package cloud.benchflow.testmanager.models.explorationspace;
+
+import cloud.benchflow.dsl.definition.types.bytes.Bytes;
+import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpace;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-07-03
+ */
+public class MongoCompatibleExplorationSpace {
+
+  // we use concrete collection classes for MongoDB + Morphia
+
+  private int size;
+  private Optional<List<Integer>> usersDimension;
+  private Optional<Map<String, List<Bytes>>> memoryDimension;
+  private Optional<Map<String, Map<String, List<String>>>> environmentDimension;
+
+  public MongoCompatibleExplorationSpace() {
+    // Empty constructor for MongoDB + Morphia
+  }
+
+  public MongoCompatibleExplorationSpace(JavaCompatExplorationSpace javaCompatExplorationSpace) {
+    this(javaCompatExplorationSpace.size(), javaCompatExplorationSpace.usersDimension(),
+        javaCompatExplorationSpace.memoryDimension(), javaCompatExplorationSpace.environment());
+  }
+
+  public MongoCompatibleExplorationSpace(int size, Optional<List<Integer>> usersDimension,
+      Optional<Map<String, List<Bytes>>> memoryDimension,
+      Optional<Map<String, Map<String, List<String>>>> environmentDimension) {
+    this.size = size;
+
+    this.usersDimension = usersDimension.map(ArrayList::new);
+
+    this.memoryDimension = memoryDimension.map(map -> new HashMap<>(map.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue())))));
+
+    this.environmentDimension =
+        environmentDimension.map(map -> new HashMap<>(map.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey,
+                e -> new HashMap<>(e.getValue().entrySet().stream().collect(
+                    Collectors.toMap(Map.Entry::getKey, e1 -> new ArrayList<>(e1.getValue()))))))));
+  }
+
+  public int getSize() {
+    return size;
+  }
+
+  public void setSize(int size) {
+    this.size = size;
+  }
+
+  public Optional<List<Integer>> getUsersDimension() {
+    return usersDimension;
+  }
+
+  public void setUsersDimension(Optional<List<Integer>> usersDimension) {
+    this.usersDimension = usersDimension;
+  }
+
+  public Optional<Map<String, List<Bytes>>> getMemoryDimension() {
+    return memoryDimension;
+  }
+
+  public void setMemoryDimension(Optional<Map<String, List<Bytes>>> memoryDimension) {
+    this.memoryDimension = memoryDimension;
+  }
+
+  public Optional<Map<String, Map<String, List<String>>>> getEnvironmentDimension() {
+    return environmentDimension;
+  }
+
+  public void setEnvironmentDimension(
+      Optional<Map<String, Map<String, List<String>>>> environmentDimension) {
+    this.environmentDimension = environmentDimension;
+  }
+
+  public JavaCompatExplorationSpace toJavaCompat() {
+
+    return new JavaCompatExplorationSpace(size,
+
+        usersDimension.map(ArrayList::new),
+
+        memoryDimension.map(map -> new HashMap<>(map.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue()))))),
+
+        environmentDimension.map(map -> new HashMap<>(map.entrySet().stream().collect(Collectors
+            .toMap(Map.Entry::getKey, e -> new HashMap<>(e.getValue().entrySet().stream().collect(
+                Collectors.toMap(Map.Entry::getKey, e1 -> new ArrayList<>(e1.getValue())))))))));
+  }
+
+}

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/explorationspace/MongoCompatibleExplorationSpaceDimensions.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/explorationspace/MongoCompatibleExplorationSpaceDimensions.java
@@ -1,0 +1,76 @@
+package cloud.benchflow.testmanager.models.explorationspace;
+
+import cloud.benchflow.dsl.definition.types.bytes.Bytes;
+import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpaceDimensions;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-07-03
+ */
+public class MongoCompatibleExplorationSpaceDimensions {
+
+  // we use concrete collection classes for MongoDB + Morphia
+
+  private Optional<List<Integer>> users;
+  private Optional<Map<String, List<Bytes>>> memory;
+  private Optional<Map<String, Map<String, List<String>>>> environment;
+
+  public MongoCompatibleExplorationSpaceDimensions() {
+    // Empty constructor for MongoDB + Morphia
+  }
+
+  public MongoCompatibleExplorationSpaceDimensions(
+      JavaCompatExplorationSpaceDimensions javaCompatExplorationSpaceDimensions) {
+    this(javaCompatExplorationSpaceDimensions.users(),
+        javaCompatExplorationSpaceDimensions.memory(),
+        javaCompatExplorationSpaceDimensions.environment());
+  }
+
+  public MongoCompatibleExplorationSpaceDimensions(Optional<List<Integer>> users,
+      Optional<Map<String, List<Bytes>>> memory,
+      Optional<Map<String, Map<String, List<String>>>> environment) {
+    this.users = users.map(ArrayList::new);
+
+    this.memory = memory.map(map -> new HashMap<>(map.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue())))));
+
+    this.environment = environment.map(map -> new HashMap<>(map.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey,
+            e -> new HashMap<>(e.getValue().entrySet().stream().collect(
+                Collectors.toMap(Map.Entry::getKey, e1 -> new ArrayList<>(e1.getValue()))))))));
+  }
+
+  public Optional<List<Integer>> getUsers() {
+    return users;
+  }
+
+  public void setUsers(Optional<List<Integer>> users) {
+    this.users = users;
+  }
+
+  public Optional<Map<String, List<Bytes>>> getMemory() {
+    return memory;
+  }
+
+  public void setMemory(Optional<Map<String, List<Bytes>>> memory) {
+    this.memory = memory;
+  }
+
+  public Optional<Map<String, Map<String, List<String>>>> getEnvironment() {
+    return environment;
+  }
+
+  public void setEnvironment(Optional<Map<String, Map<String, List<String>>>> environment) {
+    this.environment = environment;
+  }
+
+  public JavaCompatExplorationSpaceDimensions toJavaCompat() {
+    return new JavaCompatExplorationSpaceDimensions(users, memory, environment);
+  }
+
+}

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/resources/BenchFlowTestResource.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/resources/BenchFlowTestResource.java
@@ -131,8 +131,8 @@ public class BenchFlowTestResource {
           BenchFlowTestBundleExtractor.extractBPMNModelInputStreams(testBundleZipInputStream);
 
       if (deploymentDescriptorInputStream == null || bpmnModelInputStreams.size() == 0) {
-        logger.info(
-            "runBenchFlowTest: deploymentDescriptorInputStream == null || bpmnModelInputStreams.size() == 0");
+        logger.info("runBenchFlowTest: deploymentDescriptorInputStream == null "
+            + "|| bpmnModelInputStreams.size() == 0");
         throw new InvalidTestBundleException();
       }
 

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/TestTaskScheduler.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/TestTaskScheduler.java
@@ -289,7 +289,7 @@ public class TestTaskScheduler {
 
         case RUNNING:
 
-          TestRunningState runningState = testModelDAO.getTestRunningState(testID);
+          final TestRunningState runningState = testModelDAO.getTestRunningState(testID);
 
           // set test to terminated
           testModelDAO.setTestState(testID, BenchFlowTestState.TERMINATED);

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/BenchFlowTestModelDAO.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/BenchFlowTestModelDAO.java
@@ -91,7 +91,8 @@ public class BenchFlowTestModelDAO extends DAO {
   public synchronized BenchFlowTestModel getTestModel(String testID)
       throws BenchFlowTestIDDoesNotExistException {
 
-    // TODO - this should not be a public method - if an operation is needed we should add a method for it
+    // TODO - this should not be a public method - if an operation is needed
+    // we should add a method for it
 
     logger.info("getTestModel: " + testID);
 

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/DAO.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/DAO.java
@@ -3,8 +3,8 @@ package cloud.benchflow.testmanager.services.internal.dao;
 import cloud.benchflow.testmanager.constants.BenchFlowConstants;
 import cloud.benchflow.testmanager.models.BenchFlowTestModel;
 import cloud.benchflow.testmanager.models.BenchFlowTestNumber;
-import cloud.benchflow.testmanager.models.ExplorationModel;
 import cloud.benchflow.testmanager.models.User;
+import cloud.benchflow.testmanager.services.internal.dao.converters.BytesConverter;
 import cloud.benchflow.testmanager.services.internal.dao.converters.OptionalConverter;
 import cloud.benchflow.testmanager.services.internal.dao.converters.TimeConverter;
 import com.mongodb.MongoClient;
@@ -27,19 +27,21 @@ public abstract class DAO {
     morphia.map(BenchFlowTestModel.class);
     morphia.map(BenchFlowTestNumber.class);
     morphia.map(User.class);
-    morphia.map(ExplorationModel.class);
+    // morphia.map(ExplorationModel.class);
 
     // add custom mappers
     morphia.getMapper().getConverters()
         .addConverter(new OptionalConverter(morphia.getMapper().getConverters()));
 
     morphia.getMapper().getConverters().addConverter(new TimeConverter());
+    morphia.getMapper().getConverters().addConverter(new BytesConverter());
 
     // create the Datastore
     // TODO - set-up mongo DB (http://mongodb.github.io/mongo-java-driver/2.13/getting-started/quick-tour/)
     // TODO - check about resilience and cache
     datastore = morphia.createDatastore(mongoClient, BenchFlowConstants.DB_NAME);
-    datastore.ensureIndexes();
+    // TODO - to enable see issue https://github.com/benchflow/benchflow/issues/475
+    // datastore.ensureIndexes();
   }
 
   // used for testing

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/ExplorationModelDAO.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/ExplorationModelDAO.java
@@ -4,10 +4,12 @@ import cloud.benchflow.dsl.definition.configuration.goal.goaltype.GoalType;
 import cloud.benchflow.dsl.definition.configuration.strategy.regression.RegressionStrategyType;
 import cloud.benchflow.dsl.definition.configuration.strategy.selection.SelectionStrategyType;
 import cloud.benchflow.dsl.definition.configuration.strategy.validation.ValidationStrategyType;
-import cloud.benchflow.dsl.explorationspace.ExplorationSpaceGenerator.ExplorationSpace;
-import cloud.benchflow.dsl.explorationspace.ExplorationSpaceGenerator.ExplorationSpaceDimensions;
+import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpace;
+import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpaceDimensions;
 import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
 import cloud.benchflow.testmanager.models.BenchFlowTestModel;
+import cloud.benchflow.testmanager.models.explorationspace.MongoCompatibleExplorationSpace;
+import cloud.benchflow.testmanager.models.explorationspace.MongoCompatibleExplorationSpaceDimensions;
 import cloud.benchflow.testmanager.strategy.regression.MarsRegressionStrategy;
 import cloud.benchflow.testmanager.strategy.regression.RegressionStrategy;
 import cloud.benchflow.testmanager.strategy.selection.OneAtATimeSelectionStrategy;
@@ -59,8 +61,8 @@ public class ExplorationModelDAO extends DAO {
 
   }
 
-  public synchronized ExplorationSpaceDimensions getExplorationSpaceDimensions(String testID)
-      throws BenchFlowTestIDDoesNotExistException {
+  public synchronized MongoCompatibleExplorationSpaceDimensions getExplorationSpaceDimensions(
+      String testID) throws BenchFlowTestIDDoesNotExistException {
 
     logger.info("getExplorationSpaceDimensions: " + testID);
 
@@ -71,21 +73,24 @@ public class ExplorationModelDAO extends DAO {
   }
 
   public synchronized void setExplorationSpaceDimensions(String testID,
-      ExplorationSpaceDimensions explorationSpaceDimensions)
+      JavaCompatExplorationSpaceDimensions explorationSpaceDimensions)
       throws BenchFlowTestIDDoesNotExistException {
 
     logger.info("setExplorationSpaceDimensions: " + testID);
 
     final BenchFlowTestModel benchFlowTestModel = testModelDAO.getTestModel(testID);
 
+    MongoCompatibleExplorationSpaceDimensions mongoCompatibleExplorationSpaceDimensions =
+        new MongoCompatibleExplorationSpaceDimensions(explorationSpaceDimensions);
+
     benchFlowTestModel.getExplorationModel()
-        .setExplorationSpaceDimensions(explorationSpaceDimensions);
+        .setExplorationSpaceDimensions(mongoCompatibleExplorationSpaceDimensions);
 
     datastore.save(benchFlowTestModel);
 
   }
 
-  public synchronized ExplorationSpace getExplorationSpace(String testID)
+  public synchronized MongoCompatibleExplorationSpace getExplorationSpace(String testID)
       throws BenchFlowTestIDDoesNotExistException {
 
     logger.info("getExplorationSpace: " + testID);
@@ -93,17 +98,19 @@ public class ExplorationModelDAO extends DAO {
     final BenchFlowTestModel benchFlowTestModel = testModelDAO.getTestModel(testID);
 
     return benchFlowTestModel.getExplorationModel().getExplorationSpace();
-
   }
 
-  public synchronized void setExplorationSpace(String testID, ExplorationSpace explorationSpace)
-      throws BenchFlowTestIDDoesNotExistException {
+  public synchronized void setExplorationSpace(String testID,
+      JavaCompatExplorationSpace explorationSpace) throws BenchFlowTestIDDoesNotExistException {
 
     logger.info("setExplorationSpace: " + testID);
 
     final BenchFlowTestModel benchFlowTestModel = testModelDAO.getTestModel(testID);
 
-    benchFlowTestModel.getExplorationModel().setExplorationSpace(explorationSpace);
+    MongoCompatibleExplorationSpace mongoCompatibleExplorationSpace =
+        new MongoCompatibleExplorationSpace(explorationSpace);
+
+    benchFlowTestModel.getExplorationModel().setExplorationSpace(mongoCompatibleExplorationSpace);
 
     datastore.save(benchFlowTestModel);
 

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/converters/BytesConverter.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/converters/BytesConverter.java
@@ -1,0 +1,47 @@
+package cloud.benchflow.testmanager.services.internal.dao.converters;
+
+import cloud.benchflow.dsl.definition.types.bytes.Bytes;
+import org.mongodb.morphia.converters.SimpleValueConverter;
+import org.mongodb.morphia.converters.TypeConverter;
+import org.mongodb.morphia.mapping.MappedField;
+import scala.util.Try;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-07-03
+ */
+public class BytesConverter extends TypeConverter implements SimpleValueConverter {
+
+  public BytesConverter() {
+    super(Bytes.class);
+  }
+
+  @Override
+  public Object encode(Object value, MappedField optionalExtraInfo) {
+
+    if (value == null || !(value instanceof Bytes)) {
+      return null;
+    }
+
+    Bytes bytes = (Bytes) value;
+
+    return bytes.toString();
+  }
+
+  @Override
+  public Object decode(Class<?> targetClass, Object fromDBObject, MappedField optionalExtraInfo) {
+
+    if (!(fromDBObject instanceof String)) {
+      return null;
+    }
+
+    String stringValue = (String) fromDBObject;
+
+    Try<Bytes> bytesTry = Bytes.fromString(stringValue);
+
+    if (bytesTry.isFailure()) {
+      return null;
+    }
+
+    return bytesTry.get();
+  }
+}

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/converters/OptionalConverter.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/converters/OptionalConverter.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 import org.mongodb.morphia.converters.Converters;
 import org.mongodb.morphia.converters.TypeConverter;
 import org.mongodb.morphia.mapping.MappedField;
-import scala.Option;
 
 /**
  * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-06-04
@@ -17,7 +16,7 @@ public class OptionalConverter extends TypeConverter {
   private Converters converters;
 
   public OptionalConverter(Converters converters) {
-    super(Option.class);
+    super(Optional.class);
     this.converters = converters;
   }
 

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/strategy/selection/SelectionStrategy.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/strategy/selection/SelectionStrategy.java
@@ -2,7 +2,7 @@ package cloud.benchflow.testmanager.strategy.selection;
 
 import cloud.benchflow.dsl.ExplorationSpaceAPI;
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException;
-import cloud.benchflow.dsl.explorationspace.ExplorationSpaceGenerator;
+import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpace;
 import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
 import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
 import cloud.benchflow.testmanager.services.external.MinioService;
@@ -56,8 +56,12 @@ public abstract class SelectionStrategy {
       String deploymentDescriptorYamlString = IOUtils
           .toString(minioService.getTestDeploymentDescriptor(testID), StandardCharsets.UTF_8);
 
-      // JavaCompatExplorationSpace explorationSpace = explorationModelDAO.getExplorationSpace(testID);
-      ExplorationSpaceGenerator.ExplorationSpace explorationSpace =
+      // get the exploration space
+      // TODO - investigate why there is an error calling this method
+      // (e.g. instantiating scala case class)
+      //  JavaCompatExplorationSpace explorationSpace = explorationModelDAO
+      // .getExplorationSpace(testID).toJavaCompat();
+      JavaCompatExplorationSpace explorationSpace =
           ExplorationSpaceAPI.explorationSpaceFromTestYaml(testDefinitionYamlString);
 
       // next experiment to be executed
@@ -75,8 +79,8 @@ public abstract class SelectionStrategy {
           nextExplorationPoint);
 
 
-    } catch (BenchFlowTestIDDoesNotExistException | BenchFlowDeserializationException
-        | IOException e) {
+    } catch (BenchFlowTestIDDoesNotExistException | IOException
+        | BenchFlowDeserializationException e) {
       // should not happen
       // TODO - handle me
       e.printStackTrace();

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/strategy/validation/CompleteExplorationValidationStrategy.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/strategy/validation/CompleteExplorationValidationStrategy.java
@@ -2,7 +2,7 @@ package cloud.benchflow.testmanager.strategy.validation;
 
 import cloud.benchflow.dsl.ExplorationSpaceAPI;
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException;
-import cloud.benchflow.dsl.explorationspace.ExplorationSpaceGenerator;
+import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpace;
 import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
 import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
 import cloud.benchflow.testmanager.services.external.MinioService;
@@ -22,12 +22,12 @@ public class CompleteExplorationValidationStrategy implements ValidationStrategy
   private static Logger logger =
       LoggerFactory.getLogger(CompleteExplorationValidationStrategy.class.getSimpleName());
 
-  private final MinioService minioService;
   private final ExplorationModelDAO explorationModelDAO;
+  private final MinioService minioService;
 
   public CompleteExplorationValidationStrategy() {
-    this.minioService = BenchFlowTestManagerApplication.getMinioService();
     this.explorationModelDAO = BenchFlowTestManagerApplication.getExplorationModelDAO();
+    this.minioService = BenchFlowTestManagerApplication.getMinioService();
   }
 
   @Override
@@ -37,13 +37,17 @@ public class CompleteExplorationValidationStrategy implements ValidationStrategy
 
     try {
 
-      String testDefinitionYamlString =
+      // get exploration space
+      // TODO - investigate why there is an error calling this method
+      // (e.g. instantiating scala case class)
+      // JavaCompatExplorationSpace explorationSpace = explorationModelDAO
+      // .getExplorationSpace(testID).toJavaCompat();
+
+      String testDefinition =
           IOUtils.toString(minioService.getTestDefinition(testID), StandardCharsets.UTF_8);
 
-      // get exploration space
-      // JavaCompatExplorationSpace explorationSpace = explorationModelDAO.getExplorationSpace(testID);
-      ExplorationSpaceGenerator.ExplorationSpace explorationSpace =
-          ExplorationSpaceAPI.explorationSpaceFromTestYaml(testDefinitionYamlString);
+      JavaCompatExplorationSpace explorationSpace =
+          ExplorationSpaceAPI.explorationSpaceFromTestYaml(testDefinition);
 
       // get the executed exploration points
       List<Integer> explorationPointIndices =
@@ -52,8 +56,8 @@ public class CompleteExplorationValidationStrategy implements ValidationStrategy
       // if the exploration size equals the number executed points it is complete
       return explorationSpace.size() == explorationPointIndices.size();
 
-    } catch (IOException | BenchFlowDeserializationException
-        | BenchFlowTestIDDoesNotExistException e) {
+    } catch (BenchFlowTestIDDoesNotExistException | IOException
+        | BenchFlowDeserializationException e) {
       // should not happen
       // TODO - handle me
       e.printStackTrace();

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/tasks/start/StartTask.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/tasks/start/StartTask.java
@@ -1,6 +1,7 @@
 package cloud.benchflow.testmanager.tasks.start;
 
 import cloud.benchflow.dsl.BenchFlowTestAPI;
+import cloud.benchflow.dsl.ExplorationSpaceAPI;
 import cloud.benchflow.dsl.definition.BenchFlowTest;
 import cloud.benchflow.dsl.definition.configuration.goal.goaltype.GoalType;
 import cloud.benchflow.dsl.definition.configuration.strategy.regression.RegressionStrategyType;
@@ -8,6 +9,8 @@ import cloud.benchflow.dsl.definition.configuration.strategy.selection.Selection
 import cloud.benchflow.dsl.definition.configuration.strategy.validation.ValidationStrategyType;
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException;
 import cloud.benchflow.dsl.definition.types.time.Time;
+import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpace;
+import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpaceDimensions;
 import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
 import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
 import cloud.benchflow.testmanager.services.external.MinioService;
@@ -69,21 +72,22 @@ public class StartTask implements Runnable {
       Time maxRunTimeTime = test.configuration().terminationCriteria().test().maxTime();
       testModelDAO.setMaxRunTime(testID, maxRunTimeTime);
 
-      if (test.configuration().strategy().isDefined()) {
 
-        // TODO - in future PR
-        //        // get and save exploration space
-        //        JavaCompatExplorationSpace explorationSpace =
-        //            ExplorationSpace.explorationSpaceFromTestYaml(testDefinitionYamlString);
-        //
-        //        explorationModelDAO.setExplorationSpace(testID, explorationSpace);
-        //
-        //        // get and save exploration space dimensions
-        //        JavaCompatExplorationSpaceDimensions explorationSpaceDimensions =
-        //            cloud.benchflow.dsl.ExplorationSpace
-        //                .explorationSpaceDimensionsFromTestYaml(testDefinitionYamlString);
-        //
-        //        explorationModelDAO.setExplorationSpaceDimensions(testID, explorationSpaceDimensions);
+      if (test.configuration().goal().explorationSpace().isDefined()) {
+        // get and save exploration space
+        JavaCompatExplorationSpace explorationSpace =
+            ExplorationSpaceAPI.explorationSpaceFromTestYaml(testDefinitionYamlString);
+
+        explorationModelDAO.setExplorationSpace(testID, explorationSpace);
+
+        // get and save exploration space dimensions
+        JavaCompatExplorationSpaceDimensions explorationSpaceDimensions =
+            ExplorationSpaceAPI.explorationSpaceDimensionsFromTestYaml(testDefinitionYamlString);
+
+        explorationModelDAO.setExplorationSpaceDimensions(testID, explorationSpaceDimensions);
+      }
+
+      if (test.configuration().strategy().isDefined()) {
 
         // get and save selection strategy
         if (test.configuration().strategy().isDefined()) {

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/TestFiles.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/TestFiles.java
@@ -3,7 +3,10 @@ package cloud.benchflow.testmanager.helpers;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
 
 /**
  * @author Jesper Findahl (jesper.findahl@usi.ch) created on 2017-04-27
@@ -44,6 +47,15 @@ public class TestFiles {
       throws FileNotFoundException {
 
     return new FileInputStream(TEST_EXPLORATION_ONE_AT_A_TIME_USERS_MEMORY_ENVIRONMENT_FILE);
+  }
+
+  public static String getTestExplorationOneAtATimeUsersMemoryEnvironmentString()
+      throws IOException {
+
+    InputStream inputStream =
+        new FileInputStream(TEST_EXPLORATION_ONE_AT_A_TIME_USERS_MEMORY_ENVIRONMENT_FILE);
+
+    return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
   }
 
   public static InputStream getTestExplorationOneAtATimeUsersInputStream()

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/scheduler/TestTaskSchedulerIT.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/scheduler/TestTaskSchedulerIT.java
@@ -115,7 +115,7 @@ public class TestTaskSchedulerIT extends DockerComposeIT {
     testTaskScheduler.handleTestState(testID);
 
     // wait long enough for all experiments to complete
-    countDownLatch.await(10, TimeUnit.SECONDS);
+    countDownLatch.await(20, TimeUnit.SECONDS);
 
     // wait for last task to finish
     executorService.awaitTermination(1, TimeUnit.SECONDS);

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/services/internal/dao/converters/ConvertersTest.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/services/internal/dao/converters/ConvertersTest.java
@@ -1,0 +1,122 @@
+package cloud.benchflow.testmanager.services.internal.dao.converters;
+
+import cloud.benchflow.dsl.ExplorationSpaceAPI;
+import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpace;
+import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpaceDimensions;
+import cloud.benchflow.testmanager.DockerComposeIT;
+import cloud.benchflow.testmanager.helpers.TestConstants;
+import cloud.benchflow.testmanager.helpers.TestFiles;
+import cloud.benchflow.testmanager.models.BenchFlowTestModel;
+import cloud.benchflow.testmanager.models.User;
+import cloud.benchflow.testmanager.models.explorationspace.MongoCompatibleExplorationSpace;
+import cloud.benchflow.testmanager.models.explorationspace.MongoCompatibleExplorationSpaceDimensions;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mongodb.morphia.Datastore;
+import org.mongodb.morphia.Morphia;
+import org.mongodb.morphia.query.Query;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-07-03
+ */
+public class ConvertersTest extends DockerComposeIT {
+
+  private Datastore datastore;
+
+  @Before
+  public void setUp() throws Exception {
+
+    Morphia morphia = new Morphia();
+    morphia.map(User.class);
+    morphia.map(BenchFlowTestModel.class);
+    morphia.getMapper().getConverters()
+        .addConverter(new OptionalConverter(morphia.getMapper().getConverters()));
+    morphia.getMapper().getConverters().addConverter(new BytesConverter());
+
+    datastore = morphia.createDatastore(mongoClient, "morphia");
+    // TODO - to enable see issue https://github.com/benchflow/benchflow/issues/475
+    //    datastore.ensureIndexes();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    datastore.delete(datastore.createQuery(User.class));
+    datastore.delete(datastore.createQuery(BenchFlowTestModel.class));
+  }
+
+  @Test
+  public void testStoringRetrievingExplorationSpace() throws Exception {
+
+    User testUser = TestConstants.TEST_USER;
+
+    datastore.save(testUser);
+
+    final BenchFlowTestModel benchFlowTestModel =
+        new BenchFlowTestModel(TestConstants.TEST_USER, TestConstants.VALID_TEST_NAME, 1);
+
+    String testID = benchFlowTestModel.getId();
+
+    datastore.save(benchFlowTestModel);
+
+    //    ==========================
+
+    final Query<BenchFlowTestModel> testModelQuery1 =
+        datastore.createQuery(BenchFlowTestModel.class).field(BenchFlowTestModel.ID_FIELD_NAME)
+            .equal(testID);
+
+    final BenchFlowTestModel receivedTestModel1 = testModelQuery1.get();
+
+    String testDefinitionString =
+        IOUtils.toString(TestFiles.getTestExplorationOneAtATimeUsersMemoryEnvironmentInputStream(),
+            StandardCharsets.UTF_8);
+
+    JavaCompatExplorationSpace compatExplorationSpace =
+        ExplorationSpaceAPI.explorationSpaceFromTestYaml(testDefinitionString);
+
+    MongoCompatibleExplorationSpace mongoCompatibleExplorationSpace =
+        new MongoCompatibleExplorationSpace(compatExplorationSpace);
+
+    receivedTestModel1.getExplorationModel().setExplorationSpace(mongoCompatibleExplorationSpace);
+
+    datastore.save(receivedTestModel1);
+
+    //    ==========================
+
+    final Query<BenchFlowTestModel> testModelQuery2 =
+        datastore.createQuery(BenchFlowTestModel.class).field(BenchFlowTestModel.ID_FIELD_NAME)
+            .equal(testID);
+
+    final BenchFlowTestModel receivedTestModel2 = testModelQuery2.get();
+
+    JavaCompatExplorationSpaceDimensions explorationSpaceDimensions =
+        ExplorationSpaceAPI.explorationSpaceDimensionsFromTestYaml(testDefinitionString);
+
+    MongoCompatibleExplorationSpaceDimensions mongoCompatibleExplorationSpaceDimensions =
+        new MongoCompatibleExplorationSpaceDimensions(explorationSpaceDimensions);
+
+    receivedTestModel2.getExplorationModel()
+        .setExplorationSpaceDimensions(mongoCompatibleExplorationSpaceDimensions);
+
+    datastore.save(receivedTestModel2);
+
+    //    ==========================
+
+    final Query<BenchFlowTestModel> testModelQuery3 =
+        datastore.createQuery(BenchFlowTestModel.class).field(BenchFlowTestModel.ID_FIELD_NAME)
+            .equal(testID);
+
+    final BenchFlowTestModel receivedTestModel3 = testModelQuery3.get();
+
+    JavaCompatExplorationSpace javaCompatExplorationSpace =
+        receivedTestModel3.getExplorationModel().getExplorationSpace().toJavaCompat();
+
+    Assert.assertEquals(16, javaCompatExplorationSpace.size().intValue());
+
+    Assert.assertEquals(testID, receivedTestModel3.getId());
+
+  }
+}

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/strategy/selection/OneAtATimeSelectionStrategyTest.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/strategy/selection/OneAtATimeSelectionStrategyTest.java
@@ -40,6 +40,12 @@ public class OneAtATimeSelectionStrategyTest {
     Mockito.doReturn(TestFiles.getDeploymentDescriptor()).when(minioMock)
         .getTestDeploymentDescriptor(testID);
 
+    // TODO - change when converting to JavaCompatExplorationSpace works
+    //    JavaCompatExplorationSpace explorationSpace = ExplorationSpaceAPI.explorationSpaceFromTestYaml(
+    //        TestFiles.getTestExplorationOneAtATimeUsersMemoryEnvironmentString());
+    //
+    //    Mockito.doReturn(explorationSpace).when(explorationModelDAOMock).getExplorationSpace(testID);
+
     // return empty exploration point indices list
     Mockito.doReturn(new ArrayList<>()).when(explorationModelDAOMock)
         .getExecutedExplorationPointIndices(testID);

--- a/benchflow-test-manager/pom.xml
+++ b/benchflow-test-manager/pom.xml
@@ -37,7 +37,7 @@
         <dropwizard-swagger.version>1.0.6-1</dropwizard-swagger.version>
         <zt-zip.version>1.11</zt-zip.version>
         <benchflow-dsl.project.name>benchflow-dsl</benchflow-dsl.project.name>
-        <benchflow-dsl-jar.version>devel_6c5287</benchflow-dsl-jar.version>
+        <benchflow-dsl-jar.version>feature-dsl-java-compat-exploration-space_f5f26b</benchflow-dsl-jar.version>
         <benchflow-dsl.version>0.1.0</benchflow-dsl.version>
         <benchflow-faban-client.project.name>benchflow-faban-client</benchflow-faban-client.project.name>
         <benchflow-faban-client-jar.version>devel_ad148a</benchflow-faban-client-jar.version>
@@ -62,6 +62,7 @@
 
     <dependencyManagement>
         <dependencies>
+
             <dependency>
                 <groupId>io.dropwizard</groupId>
                 <artifactId>dropwizard-core</artifactId>


### PR DESCRIPTION
as per title.

Fixes (for TM) https://github.com/benchflow/benchflow/issues/391

depends on PR https://github.com/benchflow/benchflow/pull/474

This leaves an issue about creating JavaCompat* (defined in the DSL) from Java https://github.com/benchflow/benchflow/issues/477