### PR TITLE
Saves exploration space in db

### DIFF
--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/BenchFlowTestManagerApplication.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/BenchFlowTestManagerApplication.java
@@ -20,6 +20,7 @@ import io.dropwizard.setup.Environment;
 import io.federecio.dropwizard.swagger.SwaggerBundle;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,6 +128,8 @@ public class BenchFlowTestManagerApplication
     // http://mongodb.github.io/mongo-java-driver/3.4/driver/getting-started/quick-start/
     MongoClient mongoClient = configuration.getMongoDBFactory().build();
     ExecutorService taskExecutor = configuration.getTaskExecutorFactory().build(environment);
+    ScheduledThreadPoolExecutor timeOutScheduledThreadPoolExecutor =
+        new ScheduledThreadPoolExecutor(1);
 
     testModelDAO = new BenchFlowTestModelDAO(mongoClient);
     explorationModelDAO = new ExplorationModelDAO(mongoClient, testModelDAO);
@@ -137,7 +140,7 @@ public class BenchFlowTestManagerApplication
     experimentManagerService = configuration.getBenchFlowExperimentManagerServiceFactory()
         .build(configuration, environment);
 
-    testTaskScheduler = new TestTaskScheduler(taskExecutor);
+    testTaskScheduler = new TestTaskScheduler(taskExecutor, timeOutScheduledThreadPoolExecutor);
 
     // initialize to fetch dependencies
     testTaskScheduler.initialize();

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/BenchFlowTestModel.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/BenchFlowTestModel.java
@@ -4,6 +4,7 @@ import static cloud.benchflow.testmanager.constants.BenchFlowConstants.MODEL_ID_
 import static cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState.START;
 import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.DETERMINE_EXPLORATION_STRATEGY;
 
+import cloud.benchflow.dsl.definition.types.time.Time;
 import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
 import cloud.benchflow.testmanager.constants.BenchFlowConstants;
 import cloud.benchflow.testmanager.services.external.MinioService;
@@ -56,6 +57,7 @@ public class BenchFlowTestModel {
   private long number;
   private Date start = new Date();
   private Date lastModified = new Date();
+  private Time maxRunningTime;
   private BenchFlowTestState state;
   private TestRunningState runningState;
   private TestTerminatedState terminatedState;
@@ -115,6 +117,14 @@ public class BenchFlowTestModel {
 
   public Date getLastModified() {
     return lastModified;
+  }
+
+  public void setMaxRunningTime(Time maxRunningTime) {
+    this.maxRunningTime = maxRunningTime;
+  }
+
+  public Time getMaxRunningTime() {
+    return maxRunningTime;
   }
 
   public BenchFlowTestState getState() {

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/TestTaskScheduler.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/TestTaskScheduler.java
@@ -1,34 +1,22 @@
 package cloud.benchflow.testmanager.scheduler;
 
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState.TERMINATED;
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.ADD_STORED_KNOWLEDGE;
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.DERIVE_PREDICTION_FUNCTION;
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.DETERMINE_EXECUTE_EXPERIMENTS;
 import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.DETERMINE_EXECUTE_VALIDATION_SET;
 import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.HANDLE_EXPERIMENT_RESULT;
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.REMOVE_NON_REACHABLE_EXPERIMENTS;
 import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.VALIDATE_PREDICTION_FUNCTION;
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.VALIDATE_TERMINATION_CRITERIA;
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestTerminatedState.COMPLETED_WITH_FAILURE;
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestTerminatedState.GOAL_REACHED;
 
+import cloud.benchflow.dsl.definition.types.time.Time;
 import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
 import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
 import cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState;
 import cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState;
+import cloud.benchflow.testmanager.models.BenchFlowTestModel.TestTerminatedState;
+import cloud.benchflow.testmanager.scheduler.running.RunningStatesHandler;
 import cloud.benchflow.testmanager.services.internal.dao.BenchFlowTestModelDAO;
-import cloud.benchflow.testmanager.services.internal.dao.ExplorationModelDAO;
-import cloud.benchflow.testmanager.tasks.running.AddStoredKnowledgeTask;
-import cloud.benchflow.testmanager.tasks.running.DerivePredictionFunctionTask;
-import cloud.benchflow.testmanager.tasks.running.DetermineExecuteExperimentsTask;
-import cloud.benchflow.testmanager.tasks.running.DetermineExecuteInitialValidationSetTask;
-import cloud.benchflow.testmanager.tasks.running.DetermineExplorationStrategyTask;
-import cloud.benchflow.testmanager.tasks.running.HandleExperimentResultTask;
-import cloud.benchflow.testmanager.tasks.running.RemoveNonReachableExperimentsTask;
-import cloud.benchflow.testmanager.tasks.running.ValidatePredictionFunctionTask;
-import cloud.benchflow.testmanager.tasks.running.ValidateTerminationCriteria;
-import cloud.benchflow.testmanager.tasks.running.ValidateTerminationCriteria.TerminationCriteriaResult;
+import cloud.benchflow.testmanager.tasks.abort.AbortRunningTestTask;
 import cloud.benchflow.testmanager.tasks.start.StartTask;
+import cloud.benchflow.testmanager.tasks.timeout.TimeoutTask;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,6 +25,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +38,11 @@ public class TestTaskScheduler {
 
   private static Logger logger = LoggerFactory.getLogger(TestTaskScheduler.class.getSimpleName());
 
+  // stores the currently running test tasks
   private ConcurrentMap<String, Future> testTasks = new ConcurrentHashMap<>();
+
+  // stores the timeout task
+  private ConcurrentMap<String, ScheduledFuture> timeoutTasks = new ConcurrentHashMap<>();
 
   // ready queue
   private BlockingQueue<String> readyQueue = new LinkedBlockingQueue<>();
@@ -56,19 +51,25 @@ public class TestTaskScheduler {
   private BlockingQueue<String> runningQueue = new ArrayBlockingQueue<String>(1, true);
 
   private ExecutorService taskExecutorService;
+  private ScheduledThreadPoolExecutor timeoutScheduledThreadPoolExecutor;
   private BenchFlowTestModelDAO testModelDAO;
-  private ExplorationModelDAO explorationModelDAO;
 
-  public TestTaskScheduler(ExecutorService taskExecutorService) {
+  private RunningStatesHandler runningStatesHandler;
+
+  public TestTaskScheduler(ExecutorService taskExecutorService,
+      ScheduledThreadPoolExecutor timeoutScheduledThreadPoolExecutor) {
     this.taskExecutorService = taskExecutorService;
+    this.timeoutScheduledThreadPoolExecutor = timeoutScheduledThreadPoolExecutor;
   }
 
   public void initialize() {
     this.testModelDAO = BenchFlowTestManagerApplication.getTestModelDAO();
-    this.explorationModelDAO = BenchFlowTestManagerApplication.getExplorationModelDAO();
 
     // start dispatcher in separate thread
     new Thread(new TestDispatcher(readyQueue, runningQueue)).start();
+
+    this.runningStatesHandler = new RunningStatesHandler(testTasks, taskExecutorService, this);
+    this.runningStatesHandler.initialize();
 
   }
 
@@ -101,13 +102,11 @@ public class TestTaskScheduler {
           break;
 
         case WAITING:
-
           handleWaitingState(testID);
           break;
 
         case TERMINATED:
-          // remove test from running queue so dispatcher can run next test
-          runningQueue.remove(testID);
+          handleTerminatedState(testID);
           break;
 
         default:
@@ -156,6 +155,18 @@ public class TestTaskScheduler {
       // set state as ready
       testModelDAO.setTestState(testID, BenchFlowTestState.READY);
 
+      // update max running time timeout
+      ScheduledFuture timeoutTaskFuture = timeoutTasks.remove(testID);
+
+      long delay = timeoutTaskFuture.getDelay(TimeUnit.SECONDS);
+      Time remainingMaxRunningTime =
+          new Time(Duration.of(delay, ChronoUnit.SECONDS), ChronoUnit.SECONDS);
+
+      testModelDAO.setMaxRunTime(testID, remainingMaxRunningTime);
+
+      // cancel max running time timeout
+      timeoutTaskFuture.cancel(true);
+
       handleTestState(testID);
 
     } catch (BenchFlowTestIDDoesNotExistException e) {
@@ -172,44 +183,51 @@ public class TestTaskScheduler {
       logger
           .info("handleTestRunningState for " + testID + " with state " + testRunningState.name());
 
+      // set timeout if not already set
+      if (!timeoutTasks.containsKey(testID)) {
+        Time maxRunTime = testModelDAO.getMaxRunningTime(testID);
+        TimeoutTask timeoutTask = new TimeoutTask(testID, this);
+        ScheduledFuture<?> timeoutFuture = timeoutScheduledThreadPoolExecutor.schedule(timeoutTask,
+            maxRunTime.toSecondsPart(), TimeUnit.SECONDS);
+        timeoutTasks.put(testID, timeoutFuture);
+      }
+
       switch (testRunningState) {
         case DETERMINE_EXPLORATION_STRATEGY:
-          determineExplorationStrategy(testID);
+          runningStatesHandler.determineExplorationStrategy(testID);
           break;
 
         case ADD_STORED_KNOWLEDGE:
-          addStoredKnowledge(testID);
+          runningStatesHandler.addStoredKnowledge(testID);
           break;
 
         case DETERMINE_EXECUTE_VALIDATION_SET:
-          determineExecuteInitialValidationSet(testID);
+          runningStatesHandler.determineExecuteInitialValidationSet(testID);
           break;
 
         case DETERMINE_EXECUTE_EXPERIMENTS:
-          determineAndExecuteExperiments(testID);
+          runningStatesHandler.determineAndExecuteExperiments(testID);
           break;
 
         case HANDLE_EXPERIMENT_RESULT:
-          handleExperimentResult(testID);
+          runningStatesHandler.handleExperimentResult(testID);
           break;
 
         case VALIDATE_TERMINATION_CRITERIA:
-          validateTerminationCriteria(testID);
+          runningStatesHandler.validateTerminationCriteria(testID);
           break;
 
         case DERIVE_PREDICTION_FUNCTION:
           testModelDAO.setTestRunningState(testID, VALIDATE_PREDICTION_FUNCTION);
-          derivePredictionFunction(testID);
+          runningStatesHandler.derivePredictionFunction(testID);
           break;
 
         case VALIDATE_PREDICTION_FUNCTION:
-          validatePredictionFunction(testID);
-
+          runningStatesHandler.validatePredictionFunction(testID);
           break;
 
         case REMOVE_NON_REACHABLE_EXPERIMENTS:
-          removeNonReachableExperiments(testID);
-
+          runningStatesHandler.removeNonReachableExperiments(testID);
           break;
 
         default:
@@ -221,204 +239,89 @@ public class TestTaskScheduler {
     }
   }
 
-  private void determineExplorationStrategy(String testID) {
+  private void handleTerminatedState(String testID) {
+    // remove max running time timeout
+    ScheduledFuture timeoutTaskFuture = timeoutTasks.remove(testID);
+    timeoutTaskFuture.cancel(true);
 
-    logger.info("determineExplorationStrategy with testID: " + testID);
+    // remove any tasks left
+    testTasks.remove(testID);
 
-    DetermineExplorationStrategyTask task = new DetermineExplorationStrategyTask(testID);
-
-    // TODO - should go into a stateless queue (so that we can recover)
-    Future<?> future = taskExecutorService.submit(task);
-
-    // replace with new task
-    testTasks.put(testID, future);
-
-    waitForRunningTaskToComplete(testID, future, ADD_STORED_KNOWLEDGE);
+    // remove test from running queue so dispatcher can run next test
+    runningQueue.remove(testID);
   }
 
-  private void addStoredKnowledge(String testID) {
 
-    logger.info("addStoredKnowledge with testID: " + testID);
+  /**
+   * Called when user terminates test or max run time has been reached.
+   */
+  public synchronized void terminateTest(String testID) {
 
-    AddStoredKnowledgeTask task = new AddStoredKnowledgeTask(testID);
-
-    // TODO - should go into a stateless queue (so that we can recover)
-    Future<?> future = taskExecutorService.submit(task);
-
-    // replace with new task
-    testTasks.put(testID, future);
+    logger.info("terminateTest: " + testID);
 
     try {
 
-      // wait for task to complete
-      future.get();
+      BenchFlowTestState testState = testModelDAO.getTestState(testID);
 
-      boolean hasRegressionModel = explorationModelDAO.hasRegressionModel(testID);
-
-      TestRunningState nextState =
-          hasRegressionModel ? DETERMINE_EXECUTE_VALIDATION_SET : DETERMINE_EXECUTE_EXPERIMENTS;
-
-      testModelDAO.setTestRunningState(testID, nextState);
-
-      handleTestState(testID);
-
-    } catch (InterruptedException | ExecutionException e) {
-      // TODO - handle properly
-      e.printStackTrace();
-    } catch (BenchFlowTestIDDoesNotExistException e) {
-      // should not happen since it was added earlier
-      logger.error("test ID does not exist - should not happen");
-    }
-
-
-  }
-
-  private void determineExecuteInitialValidationSet(String testID) {
-
-    logger.info("determineExecuteInitialValidationSet with testID: " + testID);
-
-    DetermineExecuteInitialValidationSetTask initialValidationSetTask =
-        new DetermineExecuteInitialValidationSetTask(testID);
-
-    // TODO - should go into a stateless queue (so that we can recover)
-    Future future = taskExecutorService.submit(initialValidationSetTask);
-
-    // replace with new task
-    testTasks.put(testID, future);
-
-    waitForRunningTaskToComplete(testID, future, DETERMINE_EXECUTE_EXPERIMENTS);
-
-  }
-
-  private void determineAndExecuteExperiments(String testID) {
-
-    logger.info("determineAndExecuteExperiments with testID: " + testID);
-
-    DetermineExecuteExperimentsTask task = new DetermineExecuteExperimentsTask(testID);
-
-    // TODO - should go into a stateless queue (so that we can recover)
-    Future<?> future = taskExecutorService.submit(task);
-
-    // replace with new task
-    testTasks.put(testID, future);
-
-    // we don't wait for the task to complete since the experiment-manager
-    // will send the result
-    try {
-
-      testModelDAO.setTestRunningState(testID, HANDLE_EXPERIMENT_RESULT);
-
-    } catch (BenchFlowTestIDDoesNotExistException e) {
-      // should not happen since it was added earlier
-      logger.error("test ID does not exist - should not happen");
-    }
-  }
-
-  private void derivePredictionFunction(String testID) {
-
-    logger.info("derivePredictionFunction with testID: " + testID);
-
-    DerivePredictionFunctionTask task = new DerivePredictionFunctionTask(testID);
-
-    // TODO - should go into a stateless queue (so that we can recover)
-    Future<?> future = taskExecutorService.submit(task);
-
-    // replace with new task
-    testTasks.put(testID, future);
-
-    waitForRunningTaskToComplete(testID, future, VALIDATE_PREDICTION_FUNCTION);
-  }
-
-  private void validatePredictionFunction(String testID) {
-
-    logger.info("validatePredictionFunction with testID: " + testID);
-
-    ValidatePredictionFunctionTask task = new ValidatePredictionFunctionTask(testID);
-
-    // TODO - should go into a stateless queue (so that we can recover)
-    Future<Boolean> future = taskExecutorService.submit(task);
-
-    // replace with new task
-    testTasks.put(testID, future);
-
-    try {
-
-      boolean acceptablePredictionError = future.get();
-
-      if (acceptablePredictionError) {
-
-        testModelDAO.setTestState(testID, TERMINATED);
-        testModelDAO.setTestTerminatedState(testID, GOAL_REACHED);
-
-        // no need to execute further
-        testTasks.remove(testID);
-
-      } else {
-
-        testModelDAO.setTestRunningState(testID, REMOVE_NON_REACHABLE_EXPERIMENTS);
-
-        handleTestState(testID);
-      }
-
-    } catch (InterruptedException | ExecutionException e) {
-      // TODO - handle  properly
-      e.printStackTrace();
-    } catch (BenchFlowTestIDDoesNotExistException e) {
-      // should not happen since it was added earlier
-      logger.error("test ID does not exist - should not happen");
-    }
-  }
-
-  private void removeNonReachableExperiments(String testID) {
-
-    logger.info("removeNonReachableExperiments with testID: " + testID);
-
-    RemoveNonReachableExperimentsTask task = new RemoveNonReachableExperimentsTask(testID);
-
-    // TODO - should go into a stateless queue (so that we can recover)
-    Future<?> future = taskExecutorService.submit(task);
-
-    // replace with new task
-    testTasks.put(testID, future);
-
-    waitForRunningTaskToComplete(testID, future, DETERMINE_EXECUTE_EXPERIMENTS);
-  }
-
-  private void validateTerminationCriteria(String testID) {
-
-    logger.info("validateTerminationCriteria with testID: " + testID);
-
-    ValidateTerminationCriteria task = new ValidateTerminationCriteria(testID);
-
-    // TODO - should go into a stateless queue (so that we can recover)
-    Future<TerminationCriteriaResult> future = taskExecutorService.submit(task);
-
-    // replace with new task
-    testTasks.put(testID, future);
-
-    try {
-
-      TerminationCriteriaResult result = future.get();
-
-      switch (result) {
-
-        case GOAL_NOT_REACHABLE:
-          testModelDAO.setTestState(testID, TERMINATED);
-          testModelDAO.setTestTerminatedState(testID, COMPLETED_WITH_FAILURE);
+      switch (testState) {
+        case READY:
+          // remove from ready queue
+          readyQueue.remove(testID);
+          // set to terminated
+          testModelDAO.setTestState(testID, BenchFlowTestState.TERMINATED);
+          testModelDAO.setTestTerminatedState(testID, TestTerminatedState.PARTIALLY_COMPLETE);
+          handleTestRunningState(testID);
           break;
 
-        case GOAL_REACHABLE_REGRESSION_PREDICTION_ACCEPTABLE:
-        case GOAL_REACHABLE_NO_REGRESSION_EXPERIMENTS_EXECUTED:
-          testModelDAO.setTestState(testID, TERMINATED);
-          testModelDAO.setTestTerminatedState(testID, GOAL_REACHED);
+        case WAITING:
+        case START:
+          // set to terminated
+          testModelDAO.setTestState(testID, BenchFlowTestState.TERMINATED);
+          testModelDAO.setTestTerminatedState(testID, TestTerminatedState.PARTIALLY_COMPLETE);
+          handleTestRunningState(testID);
           break;
 
-        case GOAL_REACHABLE_REGRESSION_PREDICTION_NOT_ACCEPTABLE:
-          testModelDAO.setTestRunningState(testID, REMOVE_NON_REACHABLE_EXPERIMENTS);
+        case RUNNING:
+
+          TestRunningState runningState = testModelDAO.getTestRunningState(testID);
+
+          // set test to terminated
+          testModelDAO.setTestState(testID, BenchFlowTestState.TERMINATED);
+          testModelDAO.setTestTerminatedState(testID, TestTerminatedState.PARTIALLY_COMPLETE);
+
+          // First we wait for any currently running tasks to finish since they finish quickly.
+          // Since we already set the test state to TERMINATED the task will not continue
+          // to the next state.
+          Future runningTaskFuture = testTasks.get(testID);
+          if (runningTaskFuture != null) {
+            try {
+              runningTaskFuture.get();
+            } catch (InterruptedException | ExecutionException e) {
+              // nothing to do
+            }
+          }
+
+          if (runningState == HANDLE_EXPERIMENT_RESULT
+              || runningState == DETERMINE_EXECUTE_VALIDATION_SET) {
+
+            // if an experiment is running we cancel it on the experiment-manager
+            AbortRunningTestTask abortRunningTestTask = new AbortRunningTestTask(testID);
+            Future abortRunningTestTaskFuture = taskExecutorService.submit(abortRunningTestTask);
+
+            try {
+              abortRunningTestTaskFuture.get();
+            } catch (InterruptedException | ExecutionException e) {
+              // nothing to do
+            }
+
+          }
+
+          // once no running tasks we handle the TERMINATED state as usual
+          handleTestState(testID);
           break;
 
-        case GOAL_REACHABLE_NO_REGRESSION_EXPERIMENTS_REMAINING:
-          testModelDAO.setTestRunningState(testID, DETERMINE_EXECUTE_EXPERIMENTS);
+        case TERMINATED:
+          // already terminated
           break;
 
         default:
@@ -426,76 +329,11 @@ public class TestTaskScheduler {
           break;
       }
 
-      // run the next state
-      handleTestState(testID);
 
-    } catch (InterruptedException | ExecutionException e) {
-      // TODO - handle  properly
-      e.printStackTrace();
     } catch (BenchFlowTestIDDoesNotExistException e) {
-      // should not happen since it was added earlier
-      logger.error("test ID does not exist - should not happen");
-    }
-  }
-
-  private synchronized void handleExperimentResult(String testID) {
-
-    logger.info("handleExperimentResult with testID: " + testID);
-
-    HandleExperimentResultTask task = new HandleExperimentResultTask(testID);
-
-    // TODO - should go into a stateless queue (so that we can recover)
-    Future<?> future = taskExecutorService.submit(task);
-
-    // replace with new task
-    testTasks.put(testID, future);
-
-    try {
-
-      // wait for task to complete
-      future.get();
-
-      Boolean hasRegressionModel = explorationModelDAO.hasRegressionModel(testID);
-
-      TestRunningState nextState =
-          hasRegressionModel ? DERIVE_PREDICTION_FUNCTION : VALIDATE_TERMINATION_CRITERIA;
-
-      testModelDAO.setTestRunningState(testID, nextState);
-
-      handleTestState(testID);
-
-    } catch (InterruptedException | ExecutionException e) {
-      // TODO - handle  properly
+      // TODO - handle me
       e.printStackTrace();
-    } catch (BenchFlowTestIDDoesNotExistException e) {
-      // should not happen since it was added earlier
-      logger.error("test ID does not exist - should not happen");
     }
-  }
-
-  private void waitForRunningTaskToComplete(String testID, Future future,
-      TestRunningState nextState) {
-
-    try {
-
-      future.get();
-      testModelDAO.setTestRunningState(testID, nextState);
-      handleTestState(testID);
-
-    } catch (InterruptedException | ExecutionException e) {
-      // TODO - handle  properly
-      e.printStackTrace();
-    } catch (BenchFlowTestIDDoesNotExistException e) {
-      // should not happen since it was added earlier
-      logger.error("test ID does not exist - should not happen");
-    }
-  }
-
-  public synchronized void testMaxTimeReached(String testID) {
-
-    logger.info("testMaxTimeReached: " + testID);
-
-    // TODO - implement me
 
   }
 }

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/TestTaskScheduler.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/TestTaskScheduler.java
@@ -270,7 +270,7 @@ public class TestTaskScheduler {
           // set to terminated
           testModelDAO.setTestState(testID, BenchFlowTestState.TERMINATED);
           testModelDAO.setTestTerminatedState(testID, TestTerminatedState.PARTIALLY_COMPLETE);
-          handleTestRunningState(testID);
+          handleTestState(testID);
           break;
 
         case WAITING:
@@ -278,7 +278,7 @@ public class TestTaskScheduler {
           // set to terminated
           testModelDAO.setTestState(testID, BenchFlowTestState.TERMINATED);
           testModelDAO.setTestTerminatedState(testID, TestTerminatedState.PARTIALLY_COMPLETE);
-          handleTestRunningState(testID);
+          handleTestState(testID);
           break;
 
         case RUNNING:

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/TestTaskScheduler.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/TestTaskScheduler.java
@@ -1,5 +1,6 @@
 package cloud.benchflow.testmanager.scheduler;
 
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState.TERMINATED;
 import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.DETERMINE_EXECUTE_VALIDATION_SET;
 import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.HANDLE_EXPERIMENT_RESULT;
 import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.VALIDATE_PREDICTION_FUNCTION;
@@ -133,6 +134,11 @@ public class TestTaskScheduler {
 
       // wait for task to complete
       future.get();
+
+      if (isTerminated(testID)) {
+        // if test has been terminated we stop here
+        return;
+      }
 
       testModelDAO.setTestState(testID, BenchFlowTestState.READY);
 
@@ -333,6 +339,20 @@ public class TestTaskScheduler {
     } catch (BenchFlowTestIDDoesNotExistException e) {
       // TODO - handle me
       e.printStackTrace();
+    }
+
+  }
+
+  public boolean isTerminated(String testID) {
+
+    try {
+      BenchFlowTestState benchFlowTestState = testModelDAO.getTestState(testID);
+
+      return benchFlowTestState == TERMINATED;
+
+    } catch (BenchFlowTestIDDoesNotExistException e) {
+      // if test is not in the DB we consider it as terminated
+      return true;
     }
 
   }

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/running/RunningStatesHandler.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/running/RunningStatesHandler.java
@@ -14,7 +14,6 @@ import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestTerminat
 
 import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
 import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
-import cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState;
 import cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState;
 import cloud.benchflow.testmanager.scheduler.TestTaskScheduler;
 import cloud.benchflow.testmanager.services.internal.dao.BenchFlowTestModelDAO;
@@ -105,7 +104,7 @@ public class RunningStatesHandler {
       // wait for task to complete
       future.get();
 
-      if (isTerminated(testID)) {
+      if (testTaskScheduler.isTerminated(testID)) {
         // if test has been terminated we stop here
         return;
       }
@@ -204,7 +203,7 @@ public class RunningStatesHandler {
 
       boolean acceptablePredictionError = future.get();
 
-      if (isTerminated(testID)) {
+      if (testTaskScheduler.isTerminated(testID)) {
         // if test has been terminated we stop here
         return;
       }
@@ -261,7 +260,7 @@ public class RunningStatesHandler {
 
       TerminationCriteriaResult result = future.get();
 
-      if (isTerminated(testID)) {
+      if (testTaskScheduler.isTerminated(testID)) {
         // if test has been terminated we stop here
         return;
       }
@@ -321,7 +320,7 @@ public class RunningStatesHandler {
       // wait for task to complete
       future.get();
 
-      if (isTerminated(testID)) {
+      if (testTaskScheduler.isTerminated(testID)) {
         // if test has been terminated we stop here
         return;
       }
@@ -351,7 +350,7 @@ public class RunningStatesHandler {
 
       future.get();
 
-      if (isTerminated(testID)) {
+      if (testTaskScheduler.isTerminated(testID)) {
         // if test has been terminated we stop here
         return;
       }
@@ -366,20 +365,6 @@ public class RunningStatesHandler {
       // should not happen since it was added earlier
       logger.error("test ID does not exist - should not happen");
     }
-  }
-
-  private boolean isTerminated(String testID) {
-
-    try {
-      BenchFlowTestState benchFlowTestState = testModelDAO.getTestState(testID);
-
-      return benchFlowTestState == TERMINATED;
-
-    } catch (BenchFlowTestIDDoesNotExistException e) {
-      // if test is not in the DB we consider it as terminated
-      return true;
-    }
-
   }
 
 }

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/running/RunningStatesHandler.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/running/RunningStatesHandler.java
@@ -1,0 +1,385 @@
+package cloud.benchflow.testmanager.scheduler.running;
+
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState.TERMINATED;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.ADD_STORED_KNOWLEDGE;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.DERIVE_PREDICTION_FUNCTION;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.DETERMINE_EXECUTE_EXPERIMENTS;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.DETERMINE_EXECUTE_VALIDATION_SET;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.HANDLE_EXPERIMENT_RESULT;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.REMOVE_NON_REACHABLE_EXPERIMENTS;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.VALIDATE_PREDICTION_FUNCTION;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.VALIDATE_TERMINATION_CRITERIA;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestTerminatedState.COMPLETED_WITH_FAILURE;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestTerminatedState.GOAL_REACHED;
+
+import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
+import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
+import cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState;
+import cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState;
+import cloud.benchflow.testmanager.scheduler.TestTaskScheduler;
+import cloud.benchflow.testmanager.services.internal.dao.BenchFlowTestModelDAO;
+import cloud.benchflow.testmanager.services.internal.dao.ExplorationModelDAO;
+import cloud.benchflow.testmanager.tasks.running.AddStoredKnowledgeTask;
+import cloud.benchflow.testmanager.tasks.running.DerivePredictionFunctionTask;
+import cloud.benchflow.testmanager.tasks.running.DetermineExecuteExperimentsTask;
+import cloud.benchflow.testmanager.tasks.running.DetermineExecuteInitialValidationSetTask;
+import cloud.benchflow.testmanager.tasks.running.DetermineExplorationStrategyTask;
+import cloud.benchflow.testmanager.tasks.running.HandleExperimentResultTask;
+import cloud.benchflow.testmanager.tasks.running.RemoveNonReachableExperimentsTask;
+import cloud.benchflow.testmanager.tasks.running.ValidatePredictionFunctionTask;
+import cloud.benchflow.testmanager.tasks.running.ValidateTerminationCriteria;
+import cloud.benchflow.testmanager.tasks.running.ValidateTerminationCriteria.TerminationCriteriaResult;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-07-02
+ */
+public class RunningStatesHandler {
+
+  /**
+   * Every running state checks if the test has been terminated after each task
+   * to avoid that the test state is overwritten.
+   */
+
+  private static Logger logger =
+      LoggerFactory.getLogger(RunningStatesHandler.class.getSimpleName());
+
+  private ConcurrentMap<String, Future> testTasks;
+
+  private ExecutorService taskExecutorService;
+
+  private ExplorationModelDAO explorationModelDAO;
+  private BenchFlowTestModelDAO testModelDAO;
+
+  private TestTaskScheduler testTaskScheduler;
+
+  public RunningStatesHandler(ConcurrentMap<String, Future> testTasks,
+      ExecutorService taskExecutorService, TestTaskScheduler testTaskScheduler) {
+
+    this.testTasks = testTasks;
+    this.taskExecutorService = taskExecutorService;
+    this.testTaskScheduler = testTaskScheduler;
+  }
+
+  public void initialize() {
+
+    this.explorationModelDAO = BenchFlowTestManagerApplication.getExplorationModelDAO();
+    this.testModelDAO = BenchFlowTestManagerApplication.getTestModelDAO();
+
+  }
+
+  public void determineExplorationStrategy(String testID) {
+
+    logger.info("determineExplorationStrategy with testID: " + testID);
+
+    DetermineExplorationStrategyTask task = new DetermineExplorationStrategyTask(testID);
+
+    // TODO - should go into a stateless queue (so that we can recover)
+    Future<?> future = taskExecutorService.submit(task);
+
+    // replace with new task
+    testTasks.put(testID, future);
+
+    waitForRunningTaskToComplete(testID, future, ADD_STORED_KNOWLEDGE);
+  }
+
+  public void addStoredKnowledge(String testID) {
+
+    logger.info("addStoredKnowledge with testID: " + testID);
+
+    AddStoredKnowledgeTask task = new AddStoredKnowledgeTask(testID);
+
+    // TODO - should go into a stateless queue (so that we can recover)
+    Future<?> future = taskExecutorService.submit(task);
+
+    // replace with new task
+    testTasks.put(testID, future);
+
+    try {
+
+      // wait for task to complete
+      future.get();
+
+      if (isTerminated(testID)) {
+        // if test has been terminated we stop here
+        return;
+      }
+
+      boolean hasRegressionModel = explorationModelDAO.hasRegressionModel(testID);
+
+      TestRunningState nextState =
+          hasRegressionModel ? DETERMINE_EXECUTE_VALIDATION_SET : DETERMINE_EXECUTE_EXPERIMENTS;
+
+      testModelDAO.setTestRunningState(testID, nextState);
+
+      testTaskScheduler.handleTestState(testID);
+
+    } catch (InterruptedException | ExecutionException e) {
+      // TODO - handle properly
+      e.printStackTrace();
+    } catch (BenchFlowTestIDDoesNotExistException e) {
+      // should not happen since it was added earlier
+      logger.error("test ID does not exist - should not happen");
+    }
+
+
+  }
+
+  public void determineExecuteInitialValidationSet(String testID) {
+
+    logger.info("determineExecuteInitialValidationSet with testID: " + testID);
+
+    DetermineExecuteInitialValidationSetTask initialValidationSetTask =
+        new DetermineExecuteInitialValidationSetTask(testID);
+
+    // TODO - should go into a stateless queue (so that we can recover)
+    Future future = taskExecutorService.submit(initialValidationSetTask);
+
+    // replace with new task
+    testTasks.put(testID, future);
+
+    waitForRunningTaskToComplete(testID, future, DETERMINE_EXECUTE_EXPERIMENTS);
+
+  }
+
+  public void determineAndExecuteExperiments(String testID) {
+
+    logger.info("determineAndExecuteExperiments with testID: " + testID);
+
+    DetermineExecuteExperimentsTask task = new DetermineExecuteExperimentsTask(testID);
+
+    // TODO - should go into a stateless queue (so that we can recover)
+    Future<?> future = taskExecutorService.submit(task);
+
+    // replace with new task
+    testTasks.put(testID, future);
+
+    // we don't wait for the task to complete since the experiment-manager
+    // will send the result
+    try {
+
+      testModelDAO.setTestRunningState(testID, HANDLE_EXPERIMENT_RESULT);
+
+    } catch (BenchFlowTestIDDoesNotExistException e) {
+      // should not happen since it was added earlier
+      logger.error("test ID does not exist - should not happen");
+    }
+  }
+
+  public void derivePredictionFunction(String testID) {
+
+    logger.info("derivePredictionFunction with testID: " + testID);
+
+    DerivePredictionFunctionTask task = new DerivePredictionFunctionTask(testID);
+
+    // TODO - should go into a stateless queue (so that we can recover)
+    Future<?> future = taskExecutorService.submit(task);
+
+    // replace with new task
+    testTasks.put(testID, future);
+
+    waitForRunningTaskToComplete(testID, future, VALIDATE_PREDICTION_FUNCTION);
+  }
+
+  public void validatePredictionFunction(String testID) {
+
+    logger.info("validatePredictionFunction with testID: " + testID);
+
+    ValidatePredictionFunctionTask task = new ValidatePredictionFunctionTask(testID);
+
+    // TODO - should go into a stateless queue (so that we can recover)
+    Future<Boolean> future = taskExecutorService.submit(task);
+
+    // replace with new task
+    testTasks.put(testID, future);
+
+    try {
+
+      // TODO - update: set next state as validate termination criteria
+
+      boolean acceptablePredictionError = future.get();
+
+      if (isTerminated(testID)) {
+        // if test has been terminated we stop here
+        return;
+      }
+
+      if (acceptablePredictionError) {
+
+        testModelDAO.setTestState(testID, TERMINATED);
+        testModelDAO.setTestTerminatedState(testID, GOAL_REACHED);
+
+      } else {
+
+        testModelDAO.setTestRunningState(testID, REMOVE_NON_REACHABLE_EXPERIMENTS);
+
+        testTaskScheduler.handleTestState(testID);
+      }
+
+    } catch (InterruptedException | ExecutionException e) {
+      // TODO - handle  properly
+      e.printStackTrace();
+    } catch (BenchFlowTestIDDoesNotExistException e) {
+      // should not happen since it was added earlier
+      logger.error("test ID does not exist - should not happen");
+    }
+  }
+
+  public void removeNonReachableExperiments(String testID) {
+
+    logger.info("removeNonReachableExperiments with testID: " + testID);
+
+    RemoveNonReachableExperimentsTask task = new RemoveNonReachableExperimentsTask(testID);
+
+    // TODO - should go into a stateless queue (so that we can recover)
+    Future<?> future = taskExecutorService.submit(task);
+
+    // replace with new task
+    testTasks.put(testID, future);
+
+    waitForRunningTaskToComplete(testID, future, DETERMINE_EXECUTE_EXPERIMENTS);
+  }
+
+  public void validateTerminationCriteria(String testID) {
+
+    logger.info("validateTerminationCriteria with testID: " + testID);
+
+    ValidateTerminationCriteria task = new ValidateTerminationCriteria(testID);
+
+    // TODO - should go into a stateless queue (so that we can recover)
+    Future<TerminationCriteriaResult> future = taskExecutorService.submit(task);
+
+    // replace with new task
+    testTasks.put(testID, future);
+
+    try {
+
+      TerminationCriteriaResult result = future.get();
+
+      if (isTerminated(testID)) {
+        // if test has been terminated we stop here
+        return;
+      }
+
+      switch (result) {
+
+        case GOAL_NOT_REACHABLE:
+          testModelDAO.setTestState(testID, TERMINATED);
+          testModelDAO.setTestTerminatedState(testID, COMPLETED_WITH_FAILURE);
+          break;
+
+        case GOAL_REACHABLE_REGRESSION_PREDICTION_ACCEPTABLE:
+        case GOAL_REACHABLE_NO_REGRESSION_EXPERIMENTS_EXECUTED:
+          testModelDAO.setTestState(testID, TERMINATED);
+          testModelDAO.setTestTerminatedState(testID, GOAL_REACHED);
+          break;
+
+        case GOAL_REACHABLE_REGRESSION_PREDICTION_NOT_ACCEPTABLE:
+          testModelDAO.setTestRunningState(testID, REMOVE_NON_REACHABLE_EXPERIMENTS);
+          break;
+
+        case GOAL_REACHABLE_NO_REGRESSION_EXPERIMENTS_REMAINING:
+          testModelDAO.setTestRunningState(testID, DETERMINE_EXECUTE_EXPERIMENTS);
+          break;
+
+        default:
+          // no default
+          break;
+      }
+
+      // run the next state
+      testTaskScheduler.handleTestState(testID);
+
+    } catch (InterruptedException | ExecutionException e) {
+      // TODO - handle  properly
+      e.printStackTrace();
+    } catch (BenchFlowTestIDDoesNotExistException e) {
+      // should not happen since it was added earlier
+      logger.error("test ID does not exist - should not happen");
+    }
+  }
+
+  public synchronized void handleExperimentResult(String testID) {
+
+    logger.info("handleExperimentResult with testID: " + testID);
+
+    HandleExperimentResultTask task = new HandleExperimentResultTask(testID);
+
+    // TODO - should go into a stateless queue (so that we can recover)
+    Future<?> future = taskExecutorService.submit(task);
+
+    // replace with new task
+    testTasks.put(testID, future);
+
+    try {
+
+      // wait for task to complete
+      future.get();
+
+      if (isTerminated(testID)) {
+        // if test has been terminated we stop here
+        return;
+      }
+
+      Boolean hasRegressionModel = explorationModelDAO.hasRegressionModel(testID);
+
+      TestRunningState nextState =
+          hasRegressionModel ? DERIVE_PREDICTION_FUNCTION : VALIDATE_TERMINATION_CRITERIA;
+
+      testModelDAO.setTestRunningState(testID, nextState);
+
+      testTaskScheduler.handleTestState(testID);
+
+    } catch (InterruptedException | ExecutionException e) {
+      // TODO - handle  properly
+      e.printStackTrace();
+    } catch (BenchFlowTestIDDoesNotExistException e) {
+      // should not happen since it was added earlier
+      logger.error("test ID does not exist - should not happen");
+    }
+  }
+
+  private void waitForRunningTaskToComplete(String testID, Future future,
+      TestRunningState nextState) {
+
+    try {
+
+      future.get();
+
+      if (isTerminated(testID)) {
+        // if test has been terminated we stop here
+        return;
+      }
+
+      testModelDAO.setTestRunningState(testID, nextState);
+      testTaskScheduler.handleTestState(testID);
+
+    } catch (InterruptedException | ExecutionException e) {
+      // TODO - handle  properly
+      e.printStackTrace();
+    } catch (BenchFlowTestIDDoesNotExistException e) {
+      // should not happen since it was added earlier
+      logger.error("test ID does not exist - should not happen");
+    }
+  }
+
+  private boolean isTerminated(String testID) {
+
+    try {
+      BenchFlowTestState benchFlowTestState = testModelDAO.getTestState(testID);
+
+      return benchFlowTestState == TERMINATED;
+
+    } catch (BenchFlowTestIDDoesNotExistException e) {
+      // if test is not in the DB we consider it as terminated
+      return true;
+    }
+
+  }
+
+}

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/external/BenchFlowExperimentManagerService.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/external/BenchFlowExperimentManagerService.java
@@ -52,15 +52,16 @@ public class BenchFlowExperimentManagerService {
 
     logger.info("abortBenchFlowExperiment: " + experimentID);
 
-    Response abortPEResponse =
+    Response abortExperimentResponse =
         experimentManagerTarget.path(BenchFlowConstants.getPathFromExperimentID(experimentID))
             .path(ABORT_PATH).request().post(null);
 
-    if (abortPEResponse.getStatus() != Response.Status.NO_CONTENT.getStatusCode()) {
+    if (abortExperimentResponse.getStatus() != Response.Status.NO_CONTENT.getStatusCode()) {
 
       // TODO - handle possible errors and throw exceptions accordingly
 
-      logger.error("abortBenchFlowExperiment: error connecting - " + abortPEResponse.getStatus());
+      logger.error(
+          "abortBenchFlowExperiment: error connecting - " + abortExperimentResponse.getStatus());
 
     } else {
       logger.info("abortBenchFlowExperiment: connected successfully");

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/BenchFlowTestModelDAO.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/BenchFlowTestModelDAO.java
@@ -1,6 +1,9 @@
 package cloud.benchflow.testmanager.services.internal.dao;
 
+import cloud.benchflow.dsl.definition.types.time.Time;
 import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
+import cloud.benchflow.testmanager.models.BenchFlowExperimentModel;
+import cloud.benchflow.testmanager.models.BenchFlowExperimentModel.BenchFlowExperimentState;
 import cloud.benchflow.testmanager.models.BenchFlowTestModel;
 import cloud.benchflow.testmanager.models.BenchFlowTestNumber;
 import cloud.benchflow.testmanager.models.User;
@@ -127,6 +130,30 @@ public class BenchFlowTestModelDAO extends DAO {
         .collect(Collectors.toList());
   }
 
+
+  public synchronized void setMaxRunTime(String testID, Time maxRunTime)
+      throws BenchFlowTestIDDoesNotExistException {
+
+    logger.info("setMaxRunTime: " + testID + " : " + maxRunTime);
+
+    final BenchFlowTestModel benchFlowTestModel = getTestModel(testID);
+
+    benchFlowTestModel.setMaxRunningTime(maxRunTime);
+
+    datastore.save(benchFlowTestModel);
+
+  }
+
+  public synchronized Time getMaxRunningTime(String testID)
+      throws BenchFlowTestIDDoesNotExistException {
+
+    logger.info("getMaxRunningTime: " + testID);
+
+    final BenchFlowTestModel benchFlowTestModel = getTestModel(testID);
+
+    return benchFlowTestModel.getMaxRunningTime();
+  }
+
   public synchronized BenchFlowTestModel.BenchFlowTestState setTestState(String testID,
       BenchFlowTestModel.BenchFlowTestState state) throws BenchFlowTestIDDoesNotExistException {
 
@@ -207,5 +234,25 @@ public class BenchFlowTestModelDAO extends DAO {
     BenchFlowTestModel benchFlowTestModel = getTestModel(testID);
 
     return benchFlowTestModel.getExperimentNumbers();
+  }
+
+  public synchronized String getRunningExperiment(String testID)
+      throws BenchFlowTestIDDoesNotExistException {
+
+    logger.info("getRunningExperiment: " + testID);
+
+    BenchFlowTestModel benchFlowTestModel = getTestModel(testID);
+
+    BenchFlowExperimentModel lastExperimentModel =
+        benchFlowTestModel.getExperiments().lastEntry().getValue();
+
+    if (lastExperimentModel.getState() == BenchFlowExperimentState.RUNNING) {
+
+      return lastExperimentModel.getId();
+
+    }
+
+    return null;
+
   }
 }

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/DAO.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/DAO.java
@@ -6,6 +6,7 @@ import cloud.benchflow.testmanager.models.BenchFlowTestNumber;
 import cloud.benchflow.testmanager.models.ExplorationModel;
 import cloud.benchflow.testmanager.models.User;
 import cloud.benchflow.testmanager.services.internal.dao.converters.OptionalConverter;
+import cloud.benchflow.testmanager.services.internal.dao.converters.TimeConverter;
 import com.mongodb.MongoClient;
 import org.mongodb.morphia.Datastore;
 import org.mongodb.morphia.Morphia;
@@ -31,6 +32,8 @@ public abstract class DAO {
     // add custom mappers
     morphia.getMapper().getConverters()
         .addConverter(new OptionalConverter(morphia.getMapper().getConverters()));
+
+    morphia.getMapper().getConverters().addConverter(new TimeConverter());
 
     // create the Datastore
     // TODO - set-up mongo DB (http://mongodb.github.io/mongo-java-driver/2.13/getting-started/quick-tour/)

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/converters/TimeConverter.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/services/internal/dao/converters/TimeConverter.java
@@ -1,0 +1,49 @@
+package cloud.benchflow.testmanager.services.internal.dao.converters;
+
+import cloud.benchflow.dsl.definition.types.time.Time;
+import org.mongodb.morphia.converters.SimpleValueConverter;
+import org.mongodb.morphia.converters.TypeConverter;
+import org.mongodb.morphia.mapping.MappedField;
+import scala.util.Try;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-07-02
+ */
+public class TimeConverter extends TypeConverter implements SimpleValueConverter {
+
+
+  public TimeConverter() {
+    super(Time.class);
+  }
+
+
+  @Override
+  public Object encode(Object value, MappedField optionalExtraInfo) {
+
+    if (value == null || !(value instanceof Time)) {
+      return null;
+    }
+
+    Time time = (Time) value;
+
+    return time.toString();
+  }
+
+  @Override
+  public Object decode(Class<?> targetClass, Object fromDBObject, MappedField optionalExtraInfo) {
+
+    if (!(fromDBObject instanceof String)) {
+      return null;
+    }
+
+    String stringValue = (String) fromDBObject;
+
+    Try<Time> timeTry = Time.fromString(stringValue);
+
+    if (timeTry.isFailure()) {
+      return null;
+    }
+
+    return timeTry.get();
+  }
+}

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/tasks/abort/AbortRunningTestTask.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/tasks/abort/AbortRunningTestTask.java
@@ -1,0 +1,46 @@
+package cloud.benchflow.testmanager.tasks.abort;
+
+import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
+import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
+import cloud.benchflow.testmanager.services.external.BenchFlowExperimentManagerService;
+import cloud.benchflow.testmanager.services.internal.dao.BenchFlowTestModelDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-07-02
+ */
+public class AbortRunningTestTask implements Runnable {
+
+  private static Logger logger =
+      LoggerFactory.getLogger(AbortRunningTestTask.class.getSimpleName());
+
+  private String testID;
+  private BenchFlowExperimentManagerService experimentManagerService;
+  private BenchFlowTestModelDAO testModelDAO;
+
+  public AbortRunningTestTask(String testID) {
+    this.testID = testID;
+    this.experimentManagerService = BenchFlowTestManagerApplication.getExperimentManagerService();
+    this.testModelDAO = BenchFlowTestManagerApplication.getTestModelDAO();
+  }
+
+  @Override
+  public void run() {
+
+    logger.info("running: " + testID);
+
+    try {
+
+      String experimentID = testModelDAO.getRunningExperiment(testID);
+
+      if (experimentID != null) {
+        experimentManagerService.abortBenchFlowExperiment(experimentID);
+      }
+
+    } catch (BenchFlowTestIDDoesNotExistException e) {
+      // nothing to do
+    }
+
+  }
+}

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/tasks/start/StartTask.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/tasks/start/StartTask.java
@@ -7,9 +7,11 @@ import cloud.benchflow.dsl.definition.configuration.strategy.regression.Regressi
 import cloud.benchflow.dsl.definition.configuration.strategy.selection.SelectionStrategyType;
 import cloud.benchflow.dsl.definition.configuration.strategy.validation.ValidationStrategyType;
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException;
+import cloud.benchflow.dsl.definition.types.time.Time;
 import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
 import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
 import cloud.benchflow.testmanager.services.external.MinioService;
+import cloud.benchflow.testmanager.services.internal.dao.BenchFlowTestModelDAO;
 import cloud.benchflow.testmanager.services.internal.dao.ExplorationModelDAO;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +34,7 @@ public class StartTask implements Runnable {
   // services
   private final MinioService minioService;
   private final ExplorationModelDAO explorationModelDAO;
+  private final BenchFlowTestModelDAO testModelDAO;
 
   public StartTask(String testID) {
 
@@ -39,7 +42,7 @@ public class StartTask implements Runnable {
 
     this.minioService = BenchFlowTestManagerApplication.getMinioService();
     this.explorationModelDAO = BenchFlowTestManagerApplication.getExplorationModelDAO();
-
+    this.testModelDAO = BenchFlowTestManagerApplication.getTestModelDAO();
   }
 
   @Override
@@ -61,6 +64,10 @@ public class StartTask implements Runnable {
       if (goalType == GoalType.LOAD) {
         explorationModelDAO.setSingleExperiment(testID, true);
       }
+
+      // save max run time
+      Time maxRunTimeTime = test.configuration().terminationCriteria().test().maxTime();
+      testModelDAO.setMaxRunTime(testID, maxRunTimeTime);
 
       if (test.configuration().strategy().isDefined()) {
 

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/tasks/timeout/TimeoutTask.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/tasks/timeout/TimeoutTask.java
@@ -1,0 +1,30 @@
+package cloud.benchflow.testmanager.tasks.timeout;
+
+import cloud.benchflow.testmanager.scheduler.TestTaskScheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Jesper Findahl (jesper.findahl@gmail.com) created on 2017-07-02
+ */
+public class TimeoutTask implements Runnable {
+
+  private static Logger logger = LoggerFactory.getLogger(TimeoutTask.class.getSimpleName());
+
+  private String testID;
+  private TestTaskScheduler testTaskScheduler;
+
+  public TimeoutTask(String testID, TestTaskScheduler testTaskScheduler) {
+    this.testID = testID;
+    this.testTaskScheduler = testTaskScheduler;
+  }
+
+  @Override
+  public void run() {
+
+    logger.info("running: " + testID);
+
+    testTaskScheduler.terminateTest(testID);
+
+  }
+}

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/TestConstants.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/TestConstants.java
@@ -21,6 +21,7 @@ public class TestConstants {
 
   public static final String INVALID_TEST_NAME = "WfMSLoadTestInvalid";
   public static final String LOAD_TEST_NAME = "WfMSLoadTest";
+  public static final String TEST_TERMINATION_CRITERIA_NAME = "TestTerminationCriteriaTest";
   public static final String VALID_TEST_NAME = LOAD_TEST_NAME;
 
   public static final String INVALID_TEST_BENCHFLOW_ID = BENCHFLOW_USER_NAME + MODEL_ID_DELIMITER

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/TestFiles.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/TestFiles.java
@@ -24,6 +24,9 @@ public class TestFiles {
   private static String TEST_EXPLORATION_RANDOM_USERS_FILE = LOCAL_TESTS_FOLDER
       + "definition/exhaustive_exploration/random_breakdown/users/benchflow-test.yml";
 
+  private static String TEST_TERMINATION_CRITERIA_FILE =
+      LOCAL_TESTS_FOLDER + "definition/test_termination/benchflow-test.yml";
+
   private static String TEST_DEPLOYMENT_DESCRIPTOR =
       LOCAL_TESTS_FOLDER + "deployment/docker-compose.yml";
 
@@ -53,6 +56,11 @@ public class TestFiles {
       throws FileNotFoundException {
 
     return new FileInputStream(TEST_EXPLORATION_RANDOM_USERS_FILE);
+  }
+
+  public static InputStream getTestTerminationCriteriaInputStream() throws FileNotFoundException {
+
+    return new FileInputStream(TEST_TERMINATION_CRITERIA_FILE);
   }
 
   public static InputStream getDeploymentDescriptor() throws FileNotFoundException {

--- a/benchflow-test-manager/application/src/test/resources/data/definition/test_termination/benchflow-test.yml
+++ b/benchflow-test-manager/application/src/test/resources/data/definition/test_termination/benchflow-test.yml
@@ -1,0 +1,79 @@
+###############################################################################
+# BenchFlow Test Definition
+###############################################################################
+version: '1'
+name: TestTerminationCriteriaTest
+description: TestTerminationCriteriaTest
+
+###############################################################################
+# Test Configuration
+###############################################################################
+configuration:
+  goal:
+    type: load
+
+  users: 10
+
+  workload_execution:
+     ramp_up: 5s
+     steady_state: 60s
+     ramp_down: 5s
+
+  termination_criteria:
+    test:
+      max_time: 5s
+
+    experiment:
+      type: fixed
+      number_of_trials: 3
+
+###############################################################################
+# SUT Info Section
+###############################################################################
+sut:
+  name: camunda
+  version: 7.5.0
+  type: wfms
+
+  configuration:
+    target_service:
+      name: camunda
+      endpoint: /engine-rest
+      sut_ready_log_check: ready
+
+    deployment:
+      camunda: serverA
+      db: serverB
+
+###############################################################################
+# Workload Modeling Section
+###############################################################################
+workload:
+  test_workload:
+    driver_type: start
+    operations:
+      - test.bpmn
+
+###############################################################################
+# Data Collection Section
+###############################################################################
+data_collection:
+  client_side:
+    faban:
+      max_run_time: 1h
+      interval: 1s
+
+  server_side:
+    camunda: [properties, stats]
+
+    db:
+      mysql:
+        environment:
+          MYSQL_DB_NAME: process-engine
+          MYSQL_USER: camunda
+          MYSQL_USER_PASSWORD: camunda
+          TABLE_NAMES: ACT_HI_PROCINST,ACT_HI_ACTINST
+          MYSQL_PORT: '3306'
+          COMPLETION_QUERY: SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL
+          COMPLETION_QUERY_VALUE: '0'
+          COMPLETION_QUERY_METHOD: equal


### PR DESCRIPTION
as per title.

Fixes (for TM) https://github.com/benchflow/benchflow/issues/391

depends on PR https://github.com/benchflow/benchflow/pull/474

This leaves an issue about creating JavaCompat* (defined in the DSL) from Java https://github.com/benchflow/benchflow/issues/477