### PR TITLE
Return Exploration Space as part of Test status

### DIFF
--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/BenchFlowTestModel.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/BenchFlowTestModel.java
@@ -66,7 +66,6 @@ public class BenchFlowTestModel {
   @Reference
   private TreeMap<Long, BenchFlowExperimentModel> experiments = new TreeMap<>();
 
-  @JsonIgnore
   private ExplorationModel explorationModel = new ExplorationModel();
 
   private String testBundle;

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/explorationspace/MongoCompatibleExplorationSpaceDimensions.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/models/explorationspace/MongoCompatibleExplorationSpaceDimensions.java
@@ -17,7 +17,7 @@ public class MongoCompatibleExplorationSpaceDimensions {
   // we use concrete collection classes for MongoDB + Morphia
 
   private Optional<List<Integer>> users;
-  private Optional<Map<String, List<Bytes>>> memory;
+  private Optional<Map<String, List<String>>> memory;
   private Optional<Map<String, Map<String, List<String>>>> environment;
 
   public MongoCompatibleExplorationSpaceDimensions() {
@@ -36,8 +36,9 @@ public class MongoCompatibleExplorationSpaceDimensions {
       Optional<Map<String, Map<String, List<String>>>> environment) {
     this.users = users.map(ArrayList::new);
 
-    this.memory = memory.map(map -> new HashMap<>(map.entrySet().stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, e -> new ArrayList<>(e.getValue())))));
+    this.memory = memory.map(
+        map -> new HashMap<>(map.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
+            e -> e.getValue().stream().map(Bytes::toString).collect(Collectors.toList())))));
 
     this.environment = environment.map(map -> new HashMap<>(map.entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey,
@@ -53,11 +54,11 @@ public class MongoCompatibleExplorationSpaceDimensions {
     this.users = users;
   }
 
-  public Optional<Map<String, List<Bytes>>> getMemory() {
+  public Optional<Map<String, List<String>>> getMemory() {
     return memory;
   }
 
-  public void setMemory(Optional<Map<String, List<Bytes>>> memory) {
+  public void setMemory(Optional<Map<String, List<String>>> memory) {
     this.memory = memory;
   }
 
@@ -70,7 +71,13 @@ public class MongoCompatibleExplorationSpaceDimensions {
   }
 
   public JavaCompatExplorationSpaceDimensions toJavaCompat() {
-    return new JavaCompatExplorationSpaceDimensions(users, memory, environment);
+
+    return new JavaCompatExplorationSpaceDimensions(users,
+        memory
+            .map(map -> map.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().stream()
+                    .map(s -> Bytes.fromString(s).get()).collect(Collectors.toList())))),
+        environment);
   }
 
 }

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/TestTaskScheduler.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/scheduler/TestTaskScheduler.java
@@ -1,8 +1,8 @@
 package cloud.benchflow.testmanager.scheduler;
 
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState.*;
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.DETERMINE_EXECUTE_VALIDATION_SET;
-import static cloud.benchflow.testmanager.models.BenchFlowTestModel.TestRunningState.HANDLE_EXPERIMENT_RESULT;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState.READY;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState.TERMINATED;
+import static cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState.WAITING;
 
 import cloud.benchflow.dsl.definition.types.time.Time;
 import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
@@ -89,6 +89,12 @@ public class TestTaskScheduler {
 
   // used for testing
   @VisibleForTesting
+  protected void setRunningStatesHandler(RunningStatesHandler runningStatesHandler) {
+    this.runningStatesHandler = runningStatesHandler;
+  }
+
+  // used for testing
+  @VisibleForTesting
   protected ConcurrentMap<String, ScheduledFuture> getTimeoutTasks() {
     return timeoutTasks;
   }
@@ -99,17 +105,14 @@ public class TestTaskScheduler {
     return timeoutScheduledThreadPoolExecutor;
   }
 
-  // used for testing
-  @VisibleForTesting
-  protected void setRunningStatesHandler(RunningStatesHandler runningStatesHandler) {
-    this.runningStatesHandler = runningStatesHandler;
-  }
-
   /**
    * Handle the Starting States of a Test.
+   *
    * @param testID the test ID
    */
   public synchronized void handleStartingTest(String testID) {
+
+    logger.info("handleStartingTest for " + testID);
 
     boolean exit = false;
     BenchFlowTestState testState;
@@ -130,9 +133,12 @@ public class TestTaskScheduler {
           break;
         }
 
-        // Exit as soon as ready is executed
-        if (prevTestState != null && testState != null
-            && prevTestState.name().equals(testState.name()) && testState == READY) {
+        logger.info("handleStartingTest: prevTestState == " + prevTestState);
+        logger.info("handleStartingTest: testState == " + testState);
+
+        // Exit as soon as ready is executed, or the test has been terminated
+        if (prevTestState != null && testState != null && prevTestState == testState
+            && (testState == READY || testState == TERMINATED)) {
           exit = true;
         }
 
@@ -145,14 +151,18 @@ public class TestTaskScheduler {
 
   /**
    * Handle the Running States of a Test.
+   *
    * @param testID the test ID
    */
   public synchronized void handleRunningTest(String testID) {
+
+    logger.info("handleRunningTest for " + testID);
 
     boolean exit = false;
     BenchFlowTestState testState;
 
     try {
+
       testState = testModelDAO.getTestState(testID);
 
       // Stop when we reach a final state
@@ -167,9 +177,11 @@ public class TestTaskScheduler {
           break;
         }
 
+        logger.info("handleRunningTest: prevTestState == " + prevTestState);
+        logger.info("handleRunningTest: testState == " + testState);
+
         // Exit as soon as final state is executed
-        if (prevTestState != null && testState != null
-            && prevTestState.name().equals(testState.name())
+        if (prevTestState != null && testState != null && prevTestState == testState
             && (testState == WAITING || testState == TERMINATED)) {
           exit = true;
         }
@@ -276,11 +288,14 @@ public class TestTaskScheduler {
 
   /**
    * Handles the Running Test Sub-States.
+   *
    * @param testID the test ID
    * @throws BenchFlowTestIDDoesNotExistException when the test ID does not exists
    */
-  public synchronized void handleRunningTestState(String testID)
+  private synchronized void handleRunningTestState(String testID)
       throws BenchFlowTestIDDoesNotExistException {
+
+    logger.info("handleRunningTestState for " + testID);
 
     boolean exit = false;
     BenchFlowTestState testState;
@@ -297,6 +312,8 @@ public class TestTaskScheduler {
         e.printStackTrace();
         break;
       }
+
+      logger.info("handleRunningTestState: testState == " + testState);
 
       // Exit as soon as final state is executed
       if (testState != null && (testState == WAITING || testState == TERMINATED)) {
@@ -318,7 +335,7 @@ public class TestTaskScheduler {
     }
   }
 
-  protected synchronized BenchFlowTestState handleTestRunningState(String testID)
+  private synchronized BenchFlowTestState handleTestRunningState(String testID)
       throws BenchFlowTestIDDoesNotExistException {
 
     try {
@@ -393,12 +410,11 @@ public class TestTaskScheduler {
 
 
   /**
-   * Called when user terminates test or max run time has been reached.
-   * <p>
-   * Given that the method is not synchronized, it has not to wait that other synchronized
-   * of this class complete their execution, before getting access. This because the termination
-   * should happen as soon as it is triggered from a Timeout or a User.
-   * </p>
+   * Called when user terminates test or max run time has been reached. <p> Given that the method is
+   * not synchronized, it has not to wait that other synchronized of this class complete their
+   * execution, before getting access. This because the termination should happen as soon as it is
+   * triggered from a Timeout or a User. </p>
+   *
    * @param testID the test ID
    */
   public void terminateTest(String testID) {
@@ -435,8 +451,8 @@ public class TestTaskScheduler {
           // cancel the current running task, but let it complete before
           cancelTask(testID);
 
-          if (runningState == HANDLE_EXPERIMENT_RESULT
-              || runningState == DETERMINE_EXECUTE_VALIDATION_SET) {
+          if (runningState == TestRunningState.HANDLE_EXPERIMENT_RESULT
+              || runningState == TestRunningState.DETERMINE_EXECUTE_VALIDATION_SET) {
 
             logger.info("Need to execute AbortRunningTask");
 
@@ -513,6 +529,7 @@ public class TestTaskScheduler {
 
   /**
    * Get the Abortable Future Task from a Future.
+   *
    * @param future the AbortableFutureTask future
    * @return AbortableFutureTaskResult
    * @throws InterruptedException exception
@@ -541,48 +558,9 @@ public class TestTaskScheduler {
     return result;
   }
 
-  // holds the result of an abortable future
-  public class AbortableFutureTaskResult<T> {
-
-    // NOTE: currenlty the result is not used
-    private T result = null;
-    private boolean aborted = false;
-
-    public T getResult() {
-      // the result is only valid if the task was not aborted
-      if (!aborted)
-        return result;
-
-      return null;
-    }
-
-    /**
-     * Set the Result.
-     * @param result the test result
-     */
-    public void setResult(T result) {
-      this.result = result;
-    }
-
-    /**
-     * Check if the Test is Aborted.
-     * @return true if the test is aborted
-     */
-    public boolean isAborted() {
-      return aborted;
-    }
-
-    /**
-     * Set the Aborted Flab.
-     * @param aborted test
-     */
-    public void setAborted(boolean aborted) {
-      this.aborted = aborted;
-    }
-  }
-
   /**
    * Checks whether or not the Test reached the TERMINATED state.
+   *
    * @param testID the test ID
    * @return true if the test state is terminated.
    */
@@ -599,5 +577,49 @@ public class TestTaskScheduler {
       return true;
     }
 
+  }
+
+  // holds the result of an abortable future
+  public class AbortableFutureTaskResult<T> {
+
+    // NOTE: currenlty the result is not used
+    private T result = null;
+    private boolean aborted = false;
+
+    public T getResult() {
+      // the result is only valid if the task was not aborted
+      if (!aborted) {
+        return result;
+      }
+
+      return null;
+    }
+
+    /**
+     * Set the Result.
+     *
+     * @param result the test result
+     */
+    public void setResult(T result) {
+      this.result = result;
+    }
+
+    /**
+     * Check if the Test is Aborted.
+     *
+     * @return true if the test is aborted
+     */
+    public boolean isAborted() {
+      return aborted;
+    }
+
+    /**
+     * Set the Aborted Flab.
+     *
+     * @param aborted test
+     */
+    public void setAborted(boolean aborted) {
+      this.aborted = aborted;
+    }
   }
 }


### PR DESCRIPTION
Changes Bytes to String in ExplorationSpace to allow inclusion in response object.
Changes applied to MongoCompatibleExplorationSpace and MongoCompatibleExplorationSpaceDimensions that are part of the response when getting the test status.

fixes https://github.com/benchflow/benchflow/issues/510

note: alternative fix to what is described in issue since there is already a conversion to/from `String` and `Bytes` so we can directly store a `String` in the DB.