### PR TITLE
Fixes use case issues for Experiment Manager

### DIFF
--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/tasks/start/StartTask.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/tasks/start/StartTask.java
@@ -140,7 +140,7 @@ public class StartTask extends AbortableCallable<Boolean> {
         definitionInputStream);
     minioService.copyDeploymentDescriptorForDriversMaker(experimentID, driversMakerExperimentID,
         experimentNumber);
-    
+
     // save models for experiment
     List<String> bpmnFileNames = minioService.getAllTestBPMNModels(experimentID);
     bpmnFileNames.forEach(fileName -> minioService

--- a/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/tasks/start/StartTask.java
+++ b/benchflow-experiment-manager/application/src/main/java/cloud/benchflow/experimentmanager/tasks/start/StartTask.java
@@ -3,7 +3,6 @@ package cloud.benchflow.experimentmanager.tasks.start;
 import cloud.benchflow.dsl.BenchFlowExperimentAPI;
 import cloud.benchflow.dsl.definition.BenchFlowExperiment;
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException;
-import cloud.benchflow.dsl.definition.workload.Workload;
 import cloud.benchflow.dsl.demo.DemoConverter;
 import cloud.benchflow.experimentmanager.BenchFlowExperimentManagerApplication;
 import cloud.benchflow.experimentmanager.demo.DriversMakerCompatibleID;
@@ -19,11 +18,10 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
+import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import scala.collection.JavaConverters;
 
 /**
  * @author Jesper Findahl (jesper.findahl@usi.ch) created on 2017-04-19
@@ -142,20 +140,11 @@ public class StartTask extends AbortableCallable<Boolean> {
         definitionInputStream);
     minioService.copyDeploymentDescriptorForDriversMaker(experimentID, driversMakerExperimentID,
         experimentNumber);
-
-    // convert to Java compatible type
-    Collection<Workload> workloadCollection =
-        JavaConverters.asJavaCollectionConverter(experiment.workload().values()).asJavaCollection();
-
-    for (Workload workload : workloadCollection) {
-
-      for (String operationName : JavaConverters.asJavaCollectionConverter(workload.operations())
-          .asJavaCollection()) {
-        minioService.copyExperimentBPMNModelForDriversMaker(experimentID, driversMakerExperimentID,
-            operationName);
-      }
-
-    }
+    
+    // save models for experiment
+    List<String> bpmnFileNames = minioService.getAllTestBPMNModels(experimentID);
+    bpmnFileNames.forEach(fileName -> minioService
+        .copyExperimentBPMNModelForDriversMaker(experimentID, driversMakerExperimentID, fileName));
 
     // TODO - think how to handle this is a cleaner way
     // copy necessary mock.bpmn

--- a/benchflow-experiment-manager/pom.xml
+++ b/benchflow-experiment-manager/pom.xml
@@ -31,7 +31,7 @@
     <dropwizard.version>1.0.6</dropwizard.version>
     <dropwizard.template.config.version>1.4.0</dropwizard.template.config.version>
     <benchflow-dsl.project.name>benchflow-dsl</benchflow-dsl.project.name>
-    <benchflow-dsl-jar.version>devel_6c5287</benchflow-dsl-jar.version>
+    <benchflow-dsl-jar.version>devel_ae9e43</benchflow-dsl-jar.version>
     <benchflow-faban-client.project.name>benchflow-faban-client</benchflow-faban-client.project.name>
     <benchflow-faban-client-jar.version>devel_326a27</benchflow-faban-client-jar.version>
     <benchflow-faban-client.version>0.1.0</benchflow-faban-client.version>

--- a/benchflow-experiment-manager/pom.xml
+++ b/benchflow-experiment-manager/pom.xml
@@ -31,7 +31,7 @@
     <dropwizard.version>1.0.6</dropwizard.version>
     <dropwizard.template.config.version>1.4.0</dropwizard.template.config.version>
     <benchflow-dsl.project.name>benchflow-dsl</benchflow-dsl.project.name>
-    <benchflow-dsl-jar.version>devel_ae9e43</benchflow-dsl-jar.version>
+    <benchflow-dsl-jar.version>fix-dsl-demo-conversion-mix_df3677</benchflow-dsl-jar.version>
     <benchflow-faban-client.project.name>benchflow-faban-client</benchflow-faban-client.project.name>
     <benchflow-faban-client-jar.version>devel_326a27</benchflow-faban-client-jar.version>
     <benchflow-faban-client.version>0.1.0</benchflow-faban-client.version>


### PR DESCRIPTION
- bumps DSL version
- Adds resilience in FabanManager when getting status from Faban
- Copies all bpmn models by name for driver-maker

depends on PR https://github.com/benchflow/benchflow/pull/534