### PR TITLE
Adds REST API to abort test

### DIFF
--- a/benchflow-experiment-manager/pom.xml
+++ b/benchflow-experiment-manager/pom.xml
@@ -31,7 +31,7 @@
     <dropwizard.version>1.0.6</dropwizard.version>
     <dropwizard.template.config.version>1.4.0</dropwizard.template.config.version>
     <benchflow-dsl.project.name>benchflow-dsl</benchflow-dsl.project.name>
-    <benchflow-dsl-jar.version>fix-dm-demo-conversion-mix_8653a4</benchflow-dsl-jar.version>
+    <benchflow-dsl-jar.version>feature-dsl-semantic-validation_feb5ca</benchflow-dsl-jar.version>
     <benchflow-faban-client.project.name>benchflow-faban-client</benchflow-faban-client.project.name>
     <benchflow-faban-client-jar.version>devel_e23d01</benchflow-faban-client-jar.version>
     <benchflow-faban-client.version>0.1.0</benchflow-faban-client.version>

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/resources/BenchFlowTestResource.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/resources/BenchFlowTestResource.java
@@ -5,8 +5,6 @@ import cloud.benchflow.dsl.definition.BenchFlowTest;
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException;
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationExceptionMessage;
 import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
-import cloud.benchflow.testmanager.api.request.ChangeBenchFlowTestStateRequest;
-import cloud.benchflow.testmanager.api.response.ChangeBenchFlowTestStateResponse;
 import cloud.benchflow.testmanager.api.response.RunBenchFlowTestResponse;
 import cloud.benchflow.testmanager.bundle.BenchFlowTestBundleExtractor;
 import cloud.benchflow.testmanager.constants.BenchFlowConstants;
@@ -31,12 +29,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.zip.ZipInputStream;
 import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -57,7 +52,6 @@ import org.slf4j.LoggerFactory;
 public class BenchFlowTestResource {
 
   public static String RUN_PATH = "/run";
-  public static String STATE_PATH = "/state";
   public static String STATUS_PATH = "/status";
   public static String ABORT_PATH = "/abort";
   public static String NO_EXPLORATION_SPACE = "no exploration space";
@@ -185,34 +179,6 @@ public class BenchFlowTestResource {
       logger.error(e.getMessage());
       throw new InvalidTestBundleWebException(e.getMessage());
     }
-  }
-
-  @PUT
-  @Path("{testName}/{testNumber}/state")
-  @Consumes(MediaType.APPLICATION_JSON)
-  @Produces(MediaType.APPLICATION_JSON)
-  public ChangeBenchFlowTestStateResponse changeBenchFlowTestState(
-      @PathParam("username") String username, @PathParam("testName") String testName,
-      @PathParam("testNumber") int testNumber,
-      @NotNull @Valid final ChangeBenchFlowTestStateRequest stateRequest) {
-
-    String testID = BenchFlowConstants.getTestID(username, testName, testNumber);
-    logger
-        .info("request received: PUT " + BenchFlowConstants.getPathFromTestID(testID) + STATE_PATH);
-
-    // TODO - handle the actual state change (e.g. on Experiment Manager)
-
-    // update the state
-    BenchFlowTestModel.BenchFlowTestState newState = null;
-
-    try {
-      newState = testModelDAO.setTestState(testID, stateRequest.getState());
-    } catch (BenchFlowTestIDDoesNotExistException e) {
-      throw new InvalidBenchFlowTestIDWebException();
-    }
-
-    // return the state as saved
-    return new ChangeBenchFlowTestStateResponse(newState);
   }
 
   @Path("{testName}/{testNumber}/status")

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/resources/BenchFlowTestResource.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/resources/BenchFlowTestResource.java
@@ -239,8 +239,6 @@ public class BenchFlowTestResource {
 
   @POST
   @Path("{testName}/{testNumber}/abort")
-  @Consumes(MediaType.APPLICATION_JSON)
-  @Produces(MediaType.APPLICATION_JSON)
   public void abortBenchFlowTest(@PathParam("username") String username,
       @PathParam("testName") String testName, @PathParam("testNumber") int testNumber) {
 

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/resources/BenchFlowTestResource.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/resources/BenchFlowTestResource.java
@@ -3,6 +3,7 @@ package cloud.benchflow.testmanager.resources;
 import cloud.benchflow.dsl.BenchFlowTestAPI;
 import cloud.benchflow.dsl.definition.BenchFlowTest;
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException;
+import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationExceptionMessage;
 import cloud.benchflow.testmanager.BenchFlowTestManagerApplication;
 import cloud.benchflow.testmanager.api.request.ChangeBenchFlowTestStateRequest;
 import cloud.benchflow.testmanager.api.response.ChangeBenchFlowTestStateResponse;
@@ -171,7 +172,8 @@ public class BenchFlowTestResource {
 
       return new RunBenchFlowTestResponse(testID, statusURL);
 
-    } catch (IOException | InvalidTestBundleException | BenchFlowDeserializationException e) {
+    } catch (IOException | InvalidTestBundleException | BenchFlowDeserializationException
+        | BenchFlowDeserializationExceptionMessage e) {
       // TODO - throw more fine grained errors, e.g., file missing in bundle, deserialization error
       logger.error(e.getClass().getSimpleName());
       if (e.getMessage() == null) {

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/resources/BenchFlowTestResource.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/resources/BenchFlowTestResource.java
@@ -59,6 +59,7 @@ public class BenchFlowTestResource {
   public static String RUN_PATH = "/run";
   public static String STATE_PATH = "/state";
   public static String STATUS_PATH = "/status";
+  public static String ABORT_PATH = "/abort";
   public static String NO_EXPLORATION_SPACE = "no exploration space";
   private final BenchFlowTestModelDAO testModelDAO;
   private final UserDAO userDAO;
@@ -268,5 +269,28 @@ public class BenchFlowTestResource {
     }
 
     return benchFlowTestModel;
+  }
+
+  @POST
+  @Path("{testName}/{testNumber}/abort")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public void abortBenchFlowTest(@PathParam("username") String username,
+      @PathParam("testName") String testName, @PathParam("testNumber") int testNumber) {
+
+    String testID = BenchFlowConstants.getTestID(username, testName, testNumber);
+    logger.info(
+        "request received: POST " + BenchFlowConstants.getPathFromTestID(testID) + ABORT_PATH);
+
+    if (testModelDAO.testModelExists(testID)) {
+
+      testTaskScheduler.terminateTest(testID);
+
+    } else {
+      logger.info("abortBenchFlowTest: invalid test id - " + testID);
+      throw new InvalidBenchFlowTestIDWebException();
+
+    }
+
   }
 }

--- a/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/tasks/start/StartTask.java
+++ b/benchflow-test-manager/application/src/main/java/cloud/benchflow/testmanager/tasks/start/StartTask.java
@@ -8,6 +8,7 @@ import cloud.benchflow.dsl.definition.configuration.strategy.regression.Regressi
 import cloud.benchflow.dsl.definition.configuration.strategy.selection.SelectionStrategyType;
 import cloud.benchflow.dsl.definition.configuration.strategy.validation.ValidationStrategyType;
 import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationException;
+import cloud.benchflow.dsl.definition.errorhandling.BenchFlowDeserializationExceptionMessage;
 import cloud.benchflow.dsl.definition.types.time.Time;
 import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpace;
 import cloud.benchflow.dsl.explorationspace.JavaCompatExplorationSpaceConverter.JavaCompatExplorationSpaceDimensions;
@@ -73,7 +74,6 @@ public class StartTask extends AbortableRunnable {
       Time maxRunTimeTime = test.configuration().terminationCriteria().test().maxTime();
       testModelDAO.setMaxRunTime(testID, maxRunTimeTime);
 
-
       if (test.configuration().goal().explorationSpace().isDefined()) {
         // get and save exploration space
         JavaCompatExplorationSpace explorationSpace =
@@ -120,8 +120,8 @@ public class StartTask extends AbortableRunnable {
         explorationModelDAO.setHasRegressionModel(testID, false);
       }
 
-    } catch (BenchFlowDeserializationException | BenchFlowTestIDDoesNotExistException
-        | IOException e) {
+    } catch (BenchFlowDeserializationException | BenchFlowDeserializationExceptionMessage
+        | BenchFlowTestIDDoesNotExistException | IOException e) {
       // should not happen since it has already been tested/added
       logger.error("should not happen");
       e.printStackTrace();

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/BenchFlowTestManagerApplicationIT.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/BenchFlowTestManagerApplicationIT.java
@@ -128,59 +128,6 @@ public class BenchFlowTestManagerApplicationIT extends DockerComposeIT {
   }
 
   @Test
-  public void changeTestStateValid() throws Exception {
-
-    BenchFlowTestModelDAO testModelDAO =
-        new BenchFlowTestModelDAO(RULE.getConfiguration().getMongoDBFactory().build());
-
-    String testID =
-        testModelDAO.addTestModel(TestConstants.LOAD_TEST_NAME, TestConstants.TEST_USER);
-
-    Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
-
-    BenchFlowTestModel.BenchFlowTestState state = BenchFlowTestModel.BenchFlowTestState.TERMINATED;
-
-    ChangeBenchFlowTestStateRequest stateRequest = new ChangeBenchFlowTestStateRequest(state);
-
-    String target = "http://localhost:" + RULE.getLocalPort();
-
-    Response response = client.target(target).path(BenchFlowConstants.getPathFromTestID(testID))
-        .path(BenchFlowTestResource.STATE_PATH).request(MediaType.APPLICATION_JSON)
-        .put(Entity.entity(stateRequest, MediaType.APPLICATION_JSON));
-
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-
-    ChangeBenchFlowTestStateResponse benchFlowTestStateResponse =
-        response.readEntity(ChangeBenchFlowTestStateResponse.class);
-
-    Assert.assertEquals(state, benchFlowTestStateResponse.getState());
-
-  }
-
-  @Test
-  public void changeTestStateInvalid() throws Exception {
-
-    Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
-
-    BenchFlowTestModel.BenchFlowTestState state = BenchFlowTestModel.BenchFlowTestState.TERMINATED;
-    String testID = TestConstants.LOAD_TEST_ID;
-
-    ChangeBenchFlowTestStateRequest stateRequest = new ChangeBenchFlowTestStateRequest(state);
-
-    String target = "http://localhost:" + RULE.getLocalPort();
-
-    Response response = client.target(target).path(BenchFlowConstants.getPathFromTestID(testID))
-        .path(BenchFlowTestResource.STATE_PATH).request(MediaType.APPLICATION_JSON)
-        .put(Entity.entity(stateRequest, MediaType.APPLICATION_JSON));
-
-    Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
-
-    Assert.assertEquals(InvalidBenchFlowTestIDWebException.message,
-        response.readEntity(String.class));
-
-  }
-
-  @Test
   public void getTestStatus() throws Exception {
 
     // setup the data in the DB

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/BenchFlowTestManagerApplicationIT.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/BenchFlowTestManagerApplicationIT.java
@@ -14,13 +14,17 @@ import cloud.benchflow.testmanager.configurations.BenchFlowTestManagerConfigurat
 import cloud.benchflow.testmanager.constants.BenchFlowConstants;
 import cloud.benchflow.testmanager.exceptions.web.InvalidBenchFlowTestIDWebException;
 import cloud.benchflow.testmanager.exceptions.web.InvalidTestBundleWebException;
+import cloud.benchflow.testmanager.helpers.WaitTestCheck;
+import cloud.benchflow.testmanager.helpers.WaitTestState;
 import cloud.benchflow.testmanager.helpers.constants.TestBundle;
 import cloud.benchflow.testmanager.helpers.constants.TestConstants;
 import cloud.benchflow.testmanager.helpers.constants.TestFiles;
 import cloud.benchflow.testmanager.models.BenchFlowTestModel;
+import cloud.benchflow.testmanager.models.BenchFlowTestModel.TestTerminatedState;
 import cloud.benchflow.testmanager.models.User;
 import cloud.benchflow.testmanager.resources.BenchFlowTestResource;
 import cloud.benchflow.testmanager.resources.ExplorationPointResource;
+import cloud.benchflow.testmanager.services.external.BenchFlowExperimentManagerService;
 import cloud.benchflow.testmanager.services.internal.dao.BenchFlowExperimentModelDAO;
 import cloud.benchflow.testmanager.services.internal.dao.BenchFlowTestModelDAO;
 import cloud.benchflow.testmanager.services.internal.dao.ExplorationModelDAO;
@@ -43,6 +47,8 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
 
 /**
  * @author Jesper Findahl (jesper.findahl@usi.ch) created on 18.02.17.
@@ -67,15 +73,7 @@ public class BenchFlowTestManagerApplicationIT extends DockerComposeIT {
   @Test
   public void runBenchFlowTest() throws Exception {
 
-    // needed for multipart client
-    // https://github.com/dropwizard/dropwizard/issues/1013
-    JerseyClientConfiguration configuration = new JerseyClientConfiguration();
-    configuration.setChunkedEncodingEnabled(false);
-    // needed because parsing testYaml takes more than default time
-    configuration.setTimeout(Duration.milliseconds(5000));
-
-    Client client =
-        new JerseyClientBuilder(RULE.getEnvironment()).using(configuration).build("test client");
+    Client client = getRunTestClient();
 
     String testName = TestConstants.VALID_TEST_NAME;
     User user = BenchFlowConstants.BENCHFLOW_USER;
@@ -105,15 +103,7 @@ public class BenchFlowTestManagerApplicationIT extends DockerComposeIT {
   @Test
   public void runMissingTestDefinitionTest() throws Exception {
 
-    // needed for multipart client
-    // https://github.com/dropwizard/dropwizard/issues/1013
-    JerseyClientConfiguration configuration = new JerseyClientConfiguration();
-    configuration.setChunkedEncodingEnabled(false);
-    // needed because parsing testYaml takes more than default time
-    configuration.setTimeout(Duration.milliseconds(5000));
-
-    Client client =
-        new JerseyClientBuilder(RULE.getEnvironment()).using(configuration).build("test client");
+    Client client = getRunTestClient();
 
     User user = BenchFlowConstants.BENCHFLOW_USER;
 
@@ -310,5 +300,90 @@ public class BenchFlowTestManagerApplicationIT extends DockerComposeIT {
 
   }
 
+  @Test
+  public void abortRunningTest() throws Exception {
 
+    // setup mock of experiment manager service
+    BenchFlowExperimentManagerService experimentManagerServiceSpy =
+        Mockito.spy(BenchFlowTestManagerApplication.getExperimentManagerService());
+    BenchFlowTestManagerApplication.setExperimentManagerService(experimentManagerServiceSpy);
+
+    Mockito.doNothing().when(experimentManagerServiceSpy)
+        .runBenchFlowExperiment(Matchers.anyString());
+
+    // check for test state timeout
+    long timeout = 30 * 1000; // 30 seconds
+
+    BenchFlowTestModelDAO testModelDAO = BenchFlowTestManagerApplication.getTestModelDAO();
+    WaitTestCheck waitTestCheck = () -> Thread.sleep(100);
+
+    // ############### submit test #######################################
+
+    Client runTestClient = getRunTestClient();
+
+    User user = BenchFlowConstants.BENCHFLOW_USER;
+
+    FileDataBodyPart fileDataBodyPart = new FileDataBodyPart("benchFlowTestBundle",
+        TestBundle.getTestExplorationOneAtATimeUsersEnvironmentBundleFile(temporaryFolder),
+        MediaType.APPLICATION_OCTET_STREAM_TYPE);
+
+    MultiPart multiPart = new MultiPart();
+    multiPart.setMediaType(MediaType.MULTIPART_FORM_DATA_TYPE);
+    multiPart.bodyPart(fileDataBodyPart);
+
+    Response runResponse =
+        runTestClient.target(String.format("http://localhost:%d/", RULE.getLocalPort()))
+            .path(BenchFlowConstants.getPathFromUsername(user.getUsername()))
+            .path(BenchFlowConstants.TESTS_PATH).path(BenchFlowTestResource.RUN_PATH)
+            .register(MultiPartFeature.class).request(MediaType.APPLICATION_JSON)
+            .post(Entity.entity(multiPart, multiPart.getMediaType()));
+
+    Assert.assertEquals(Response.Status.OK.getStatusCode(), runResponse.getStatus());
+
+    RunBenchFlowTestResponse runTestResponse =
+        runResponse.readEntity(RunBenchFlowTestResponse.class);
+
+    String testID = runTestResponse.getTestID();
+
+    // ############### wait for test to go into running state ############
+
+    WaitTestState.waitForTestRunningWithTimeout(testID, testModelDAO, waitTestCheck, timeout);
+
+    // ############### abort test while running ##########################
+
+    JerseyClientConfiguration configuration = new JerseyClientConfiguration();
+    // needed because parsing testYaml takes more than default time
+    configuration.setTimeout(Duration.milliseconds(1000));
+
+    Client client =
+        new JerseyClientBuilder(RULE.getEnvironment()).using(configuration).build("test client");
+
+    String target = "http://localhost:" + RULE.getLocalPort();
+
+    Response response = client.target(target).path(BenchFlowConstants.getPathFromTestID(testID))
+        .path(BenchFlowTestResource.ABORT_PATH).request().post(null);
+
+    Assert.assertEquals(Status.NO_CONTENT.getStatusCode(), response.getStatus());
+
+    // ############### assert test is partially complete #################
+
+    WaitTestState.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck, timeout);
+
+    TestTerminatedState terminatedState = testModelDAO.getTestTerminatedState(testID);
+
+    Assert.assertEquals(TestTerminatedState.PARTIALLY_COMPLETE, terminatedState);
+
+  }
+
+  private Client getRunTestClient() {
+    // needed for multipart client
+    // https://github.com/dropwizard/dropwizard/issues/1013
+    JerseyClientConfiguration configuration = new JerseyClientConfiguration();
+    configuration.setChunkedEncodingEnabled(false);
+    // needed because parsing testYaml takes more than default time
+    configuration.setTimeout(Duration.milliseconds(5000));
+
+    return new JerseyClientBuilder(RULE.getEnvironment()).using(configuration)
+        .build("test run client");
+  }
 }

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/TestManagerSmokeTestsIT.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/TestManagerSmokeTestsIT.java
@@ -217,7 +217,7 @@ public class TestManagerSmokeTestsIT extends DockerComposeIT {
   public void runTestMultipleServicesUsersFile() throws Exception {
 
     String testName = "WfMSMemoryEnvironmentStepUsersExhaustiveExplorationTest";
-    int expectedNumExperiments = 12;
+    int expectedNumExperiments = 16;
 
     FileDataBodyPart fileDataBodyPart = new FileDataBodyPart("benchFlowTestBundle",
         TestBundle.getTestMultipleServicesUsersBundleFile(temporaryFolder),
@@ -305,6 +305,7 @@ public class TestManagerSmokeTestsIT extends DockerComposeIT {
 
     // assert all test were executed
     Set<Long> experimentNumbers = testModelDAO.getExperimentNumbers(getExpectedTestID(testName));
+    Assert.assertEquals(expectedNumExperiments, experimentNumbers.size());
     for (long i = 1; i <= expectedNumExperiments; i++) {
       Assert.assertTrue(experimentNumbers.contains(i));
     }

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/TestManagerSmokeTestsIT.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/TestManagerSmokeTestsIT.java
@@ -10,7 +10,7 @@ import cloud.benchflow.testmanager.api.response.RunBenchFlowTestResponse;
 import cloud.benchflow.testmanager.configurations.BenchFlowTestManagerConfiguration;
 import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
 import cloud.benchflow.testmanager.helpers.WaitTestCheck;
-import cloud.benchflow.testmanager.helpers.WaitTestTermination;
+import cloud.benchflow.testmanager.helpers.WaitTestState;
 import cloud.benchflow.testmanager.helpers.constants.TestBundle;
 import cloud.benchflow.testmanager.models.BenchFlowExperimentModel.BenchFlowExperimentState;
 import cloud.benchflow.testmanager.models.BenchFlowExperimentModel.TerminatedState;
@@ -293,8 +293,8 @@ public class TestManagerSmokeTestsIT extends DockerComposeIT {
 
     };
 
-    WaitTestTermination.waitForTestTerminationWithTimeout(expectedTestID, testModelDAO,
-        waitTestCheck, timeout);
+    WaitTestState.waitForTestTerminationWithTimeout(expectedTestID, testModelDAO, waitTestCheck,
+        timeout);
 
     // assert test was terminated
     BenchFlowTestState testState = testModelDAO.getTestState(expectedTestID);

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/TestManagerSmokeTestsIT.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/TestManagerSmokeTestsIT.java
@@ -213,6 +213,20 @@ public class TestManagerSmokeTestsIT extends DockerComposeIT {
 
   }
 
+  @Test
+  public void runTestMultipleServicesUsersFile() throws Exception {
+
+    String testName = "WfMSMemoryEnvironmentStepUsersExhaustiveExplorationTest";
+    int expectedNumExperiments = 12;
+
+    FileDataBodyPart fileDataBodyPart = new FileDataBodyPart("benchFlowTestBundle",
+        TestBundle.getTestMultipleServicesUsersBundleFile(temporaryFolder),
+        MediaType.APPLICATION_OCTET_STREAM_TYPE);
+
+    runTest(testName, fileDataBodyPart, expectedNumExperiments);
+
+  }
+
   private void runTest(String testName, FileDataBodyPart fileDataBodyPart,
       int expectedNumExperiments)
       throws BenchFlowTestIDDoesNotExistException, InterruptedException {

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/WaitTestState.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/WaitTestState.java
@@ -2,14 +2,16 @@ package cloud.benchflow.testmanager.helpers;
 
 import cloud.benchflow.testmanager.exceptions.BenchFlowTestIDDoesNotExistException;
 import cloud.benchflow.testmanager.models.BenchFlowTestModel;
+import cloud.benchflow.testmanager.models.BenchFlowTestModel.BenchFlowTestState;
 import cloud.benchflow.testmanager.services.internal.dao.BenchFlowTestModelDAO;
 
 /**
  * Waits for test termination while triggering a callback.
  *
  * @author Vincenzo Ferme (info@vincenzoferme.it)
+ * @author Jesper Findahl (jesper.findahl@usi.ch)
  */
-public abstract class WaitTestTermination {
+public abstract class WaitTestState {
 
   public static void waitForTestTerminationWithTimeout(String testID,
       BenchFlowTestModelDAO testModelDAO, WaitTestCheck waitTestCheck, long timeout)
@@ -19,6 +21,20 @@ public abstract class WaitTestTermination {
 
     while (!testModelDAO.getTestState(testID)
         .equals(BenchFlowTestModel.BenchFlowTestState.TERMINATED)
+        && (System.currentTimeMillis() - startTime) < timeout) {
+
+      waitTestCheck.checkTestIsFinished();
+
+    }
+  }
+
+  public static void waitForTestRunningWithTimeout(String testID,
+      BenchFlowTestModelDAO testModelDAO, WaitTestCheck waitTestCheck, long timeout)
+      throws BenchFlowTestIDDoesNotExistException, InterruptedException {
+
+    long startTime = System.currentTimeMillis(); //fetch starting time
+
+    while (!testModelDAO.getTestState(testID).equals(BenchFlowTestState.RUNNING)
         && (System.currentTimeMillis() - startTime) < timeout) {
 
       waitTestCheck.checkTestIsFinished();

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/constants/TestBundle.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/constants/TestBundle.java
@@ -113,6 +113,17 @@ public class TestBundle {
 
   }
 
+  public static File getTestMultipleServicesUsersBundleFile(TemporaryFolder temporaryFolder)
+      throws IOException {
+
+    FileSource testDefinitionFileSource =
+        new FileSource(TestFiles.getTestMultipleServicesUsersFile().getName(),
+            TestFiles.getTestMultipleServicesUsersFile());
+
+    return createBundleFile(testDefinitionFileSource, temporaryFolder);
+
+  }
+
 
 
   /**

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/constants/TestFiles.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/helpers/constants/TestFiles.java
@@ -39,6 +39,9 @@ public class TestFiles {
   private static String TEST_STEP_USERS_FILE =
       LOCAL_TESTS_FOLDER + "definition/step/users/benchflow-test.yml";
 
+  private static String TEST_EXPLORATION_MULTIPLE_SERVICES_USERS_FILE = LOCAL_TESTS_FOLDER
+      + "definition/exhaustive_exploration/one-at-a-time/multiple-services/benchflow-test.yml";
+
   private static String TEST_DEPLOYMENT_DESCRIPTOR =
       LOCAL_TESTS_FOLDER + "deployment/docker-compose.yml";
 
@@ -118,6 +121,10 @@ public class TestFiles {
   public static File getTestStepUsersFile() throws FileNotFoundException {
 
     return new File(TEST_STEP_USERS_FILE);
+  }
+
+  public static File getTestMultipleServicesUsersFile() throws FileNotFoundException {
+    return new File(TEST_EXPLORATION_MULTIPLE_SERVICES_USERS_FILE);
   }
 
   public static InputStream getDeploymentDescriptor() throws FileNotFoundException {

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/resources/BenchFlowTestResourceTest.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/resources/BenchFlowTestResourceTest.java
@@ -110,55 +110,6 @@ public class BenchFlowTestResourceTest {
   }
 
   @Test
-  public void changeBenchFlowTestState() throws Exception {
-
-    Mockito.doReturn(RUNNING).when(testModelDAOMock).setTestState(TestConstants.VALID_TEST_ID,
-        RUNNING);
-    Mockito.doReturn(TERMINATED).when(testModelDAOMock).setTestState(TestConstants.VALID_TEST_ID,
-        TERMINATED);
-
-    request.setState(RUNNING);
-
-    String[] testIDArray = TestConstants.VALID_TEST_ID.split(MODEL_ID_DELIMITER_REGEX);
-
-    String username = testIDArray[0];
-    String testName = testIDArray[1];
-    int testNumber = Integer.parseInt(testIDArray[2]);
-
-    ChangeBenchFlowTestStateResponse response =
-        resource.changeBenchFlowTestState(username, testName, testNumber, request);
-
-    Assert.assertNotNull(response);
-    Assert.assertEquals(RUNNING, response.getState());
-
-    request.setState(TERMINATED);
-
-    response = resource.changeBenchFlowTestState(username, testName, testNumber, request);
-
-    Assert.assertNotNull(response);
-    Assert.assertEquals(TERMINATED, response.getState());
-  }
-
-  @Test
-  public void changeBenchFlowTestStateInvalid() throws Exception {
-
-    request.setState(RUNNING);
-
-    Mockito.doThrow(BenchFlowTestIDDoesNotExistException.class).when(testModelDAOMock)
-        .setTestState(TestConstants.VALID_TEST_ID, RUNNING);
-
-    exception.expect(InvalidBenchFlowTestIDWebException.class);
-
-    String[] testIDArray = TestConstants.VALID_TEST_ID.split(MODEL_ID_DELIMITER_REGEX);
-
-    String username = testIDArray[0];
-    String testName = testIDArray[1];
-    int testNumber = Integer.parseInt(testIDArray[2]);
-
-    resource.changeBenchFlowTestState(username, testName, testNumber, request);
-  }
-
-  @Test
   public void getBenchFlowTestStatusInValid() throws Exception {
 
     String testID = TestConstants.INVALID_TEST_BENCHFLOW_ID;

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/resources/BenchFlowTestResourceTest.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/resources/BenchFlowTestResourceTest.java
@@ -242,4 +242,27 @@ public class BenchFlowTestResourceTest {
     Assert.assertEquals(BenchFlowTestResource.NO_EXPLORATION_SPACE, explorationPointURL);
 
   }
+
+  @Test
+  public void abortInvalidRunningTest() throws Exception {
+
+    String testID = TestConstants.INVALID_TEST_BENCHFLOW_ID;
+
+    Mockito.doThrow(BenchFlowTestIDDoesNotExistException.class).when(testModelDAOMock)
+        .getTestModel(testID);
+
+    exception.expect(InvalidBenchFlowTestIDWebException.class);
+
+    String[] testIDArray = TestConstants.INVALID_TEST_BENCHFLOW_ID.split(MODEL_ID_DELIMITER_REGEX);
+
+    String username = testIDArray[0];
+    String testName = testIDArray[1];
+    int testNumber = Integer.parseInt(testIDArray[2]);
+
+    resource.abortBenchFlowTest(username, testName, testNumber);
+
+    Mockito.verify(testModelDAOMock, Mockito.times(1)).getTestModel(testID);
+
+
+  }
 }

--- a/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/scheduler/TestTaskSchedulerIT.java
+++ b/benchflow-test-manager/application/src/test/java/cloud/benchflow/testmanager/scheduler/TestTaskSchedulerIT.java
@@ -9,7 +9,7 @@ import cloud.benchflow.testmanager.DockerComposeIT;
 import cloud.benchflow.testmanager.configurations.BenchFlowTestManagerConfiguration;
 import cloud.benchflow.testmanager.constants.BenchFlowConstants;
 import cloud.benchflow.testmanager.helpers.WaitTestCheck;
-import cloud.benchflow.testmanager.helpers.WaitTestTermination;
+import cloud.benchflow.testmanager.helpers.WaitTestState;
 import cloud.benchflow.testmanager.helpers.constants.TestBundle;
 import cloud.benchflow.testmanager.helpers.constants.TestConstants;
 import cloud.benchflow.testmanager.helpers.constants.TestFiles;
@@ -141,8 +141,7 @@ public class TestTaskSchedulerIT extends DockerComposeIT {
       executorService.awaitTermination(1, TimeUnit.SECONDS);
     };
 
-    WaitTestTermination.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck,
-        timeout);
+    WaitTestState.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck, timeout);
 
     // assert that all experiments have been executed
     Assert.assertEquals(0, countDownLatch.getCount());
@@ -202,8 +201,7 @@ public class TestTaskSchedulerIT extends DockerComposeIT {
       countDownLatch.await(10, TimeUnit.SECONDS);
     };
 
-    WaitTestTermination.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck,
-        timeout);
+    WaitTestState.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck, timeout);
 
     // wait for last task to finish
     executorService.awaitTermination(1, TimeUnit.SECONDS);
@@ -269,8 +267,7 @@ public class TestTaskSchedulerIT extends DockerComposeIT {
       executorService.awaitTermination(10, TimeUnit.SECONDS);
     };
 
-    WaitTestTermination.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck,
-        timeout);
+    WaitTestState.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck, timeout);
 
     // assert that all experiments have been executed
     Assert.assertEquals(0, countDownLatch.getCount());
@@ -337,8 +334,7 @@ public class TestTaskSchedulerIT extends DockerComposeIT {
       executorService.awaitTermination(1, TimeUnit.SECONDS);
     };
 
-    WaitTestTermination.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck,
-        timeout);
+    WaitTestState.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck, timeout);
 
     // assert that all experiments have been executed
     Assert.assertEquals(0, countDownLatch.getCount());
@@ -411,8 +407,7 @@ public class TestTaskSchedulerIT extends DockerComposeIT {
 
     };
 
-    WaitTestTermination.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck,
-        timeout);
+    WaitTestState.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck, timeout);
 
     // assert that test has been set as TERMINATED
     Assert.assertEquals(BenchFlowTestModel.BenchFlowTestState.TERMINATED,
@@ -492,8 +487,7 @@ public class TestTaskSchedulerIT extends DockerComposeIT {
 
     };
 
-    WaitTestTermination.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck,
-        timeout);
+    WaitTestState.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck, timeout);
 
     // assert that test has been set as TERMINATED
     Assert.assertEquals(BenchFlowTestModel.BenchFlowTestState.TERMINATED,
@@ -621,7 +615,7 @@ public class TestTaskSchedulerIT extends DockerComposeIT {
   //
   //    };
   //
-  //    WaitTestTermination.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck, timeout);
+  //    WaitTestState.waitForTestTerminationWithTimeout(testID, testModelDAO, waitTestCheck, timeout);
   //
   //    // assert that test has been set as TERMINATED
   //    Assert.assertEquals(BenchFlowTestModel.BenchFlowTestState.TERMINATED,

--- a/benchflow-test-manager/application/src/test/resources/data/definition/exhaustive_exploration/one-at-a-time/memory/benchflow-test.yml
+++ b/benchflow-test-manager/application/src/test/resources/data/definition/exhaustive_exploration/one-at-a-time/memory/benchflow-test.yml
@@ -18,6 +18,8 @@ configuration:
           memory:
             values: [500m, 1000m]
 
+  users: 50
+
   strategy:
     selection: one-at-a-time
 

--- a/benchflow-test-manager/application/src/test/resources/data/definition/exhaustive_exploration/one-at-a-time/multiple-services/benchflow-test.yml
+++ b/benchflow-test-manager/application/src/test/resources/data/definition/exhaustive_exploration/one-at-a-time/multiple-services/benchflow-test.yml
@@ -1,0 +1,94 @@
+###############################################################################
+# BenchFlow Test Definition
+###############################################################################
+version: '1'
+name: WfMSMemoryEnvironmentStepUsersExhaustiveExplorationTest
+description: WfMSMemoryEnvironmentStepUsersExhaustiveExplorationTest
+
+###############################################################################
+# Test Configuration
+###############################################################################
+configuration:
+  goal:
+    type: exhaustive_exploration
+
+    exploration_space:
+      camunda:
+        resources:
+          memory:
+            values: [4g, 8g]
+      db:
+        environment:
+          JAVA_OPTS: ["-Xms128m", "-Xms1024m"]
+
+      workload:
+        users:
+          range: [50, 250]
+          step: '*2'
+
+  strategy:
+    selection: one-at-a-time
+
+  workload_execution:
+     ramp_up: 30s
+     steady_state: 10m
+     ramp_down: 30s
+
+  termination_criteria:
+    test:
+      max_time: 16h
+
+    experiment:
+      type: fixed
+      number_of_trials: 3
+
+###############################################################################
+# SUT Info Section
+###############################################################################
+sut:
+  name: camunda
+  version: 7.5.0
+  type: wfms
+
+  configuration:
+    target_service:
+      name: camunda
+      endpoint: /engine-rest
+      sut_ready_log_check: ready
+
+    deployment:
+      camunda: serverA
+      db: serverB
+
+###############################################################################
+# Workload Modeling Section
+###############################################################################
+workload:
+  test_workload:
+    driver_type: start
+    operations:
+      - test.bpmn
+
+###############################################################################
+# Data Collection Section
+###############################################################################
+data_collection:
+  client_side:
+    faban:
+      max_run_time: 1h
+      interval: 1s
+
+  server_side:
+    camunda: [properties, stats]
+
+    db:
+      mysql:
+        environment:
+          MYSQL_DB_NAME: process-engine
+          MYSQL_USER: camunda
+          MYSQL_USER_PASSWORD: camunda
+          TABLE_NAMES: ACT_HI_PROCINST,ACT_HI_ACTINST
+          MYSQL_PORT: '3306'
+          COMPLETION_QUERY: SELECT+COUNT(*)+FROM+ACT_HI_PROCINST+WHERE+END_TIME_+IS+NULL
+          COMPLETION_QUERY_VALUE: '0'
+          COMPLETION_QUERY_METHOD: equal

--- a/benchflow-test-manager/pom.xml
+++ b/benchflow-test-manager/pom.xml
@@ -38,7 +38,7 @@
         <dropwizard-swagger.version>1.0.6-1</dropwizard-swagger.version>
         <zt-zip.version>1.11</zt-zip.version>
         <benchflow-dsl.project.name>benchflow-dsl</benchflow-dsl.project.name>
-        <benchflow-dsl-jar.version>fix-dm-demo-conversion-mix_8653a4</benchflow-dsl-jar.version>
+        <benchflow-dsl-jar.version>feature-dsl-semantic-validation_feb5ca</benchflow-dsl-jar.version>
         <benchflow-dsl.version>0.1.0</benchflow-dsl.version>
         <benchflow-faban-client.project.name>benchflow-faban-client</benchflow-faban-client.project.name>
         <benchflow-faban-client-jar.version>devel_e23d01</benchflow-faban-client-jar.version>


### PR DESCRIPTION
as per title

Also removes the REST API to change the state of a test since it is not needed when we have the abort API, and also it is not working properly with the current implementation of the scheduler.

depends on PR https://github.com/benchflow/benchflow/pull/554